### PR TITLE
Craftable mutation toxins

### DIFF
--- a/code/modules/reagents/chemistry/recipes/bungalowmutation
+++ b/code/modules/reagents/chemistry/recipes/bungalowmutation
@@ -1,0 +1,23 @@
+/datum/chemical_reaction/mutationtoxin_moth
+	results = list(/datum/reagent/mutationtoxin/moth = 2)
+	required_reagents = list(/datum/reagent/mutationtoxin/jelly = 1, /datum/reagent/cellulose = 1)
+
+/datum/chemical_reaction/mutationtoxin_felinid
+	results = list(/datum/reagent/mutationtoxin/felinid = 2)
+	required_reagents = list(/datum/reagent/mutationtoxin/jelly = 1, /datum/reagent/liquidgibs = 1)
+
+/datum/chemical_reaction/mutationtoxin_fly
+	results = list(/datum/reagent/mutationtoxin/fly = 2)
+	required_reagents = list(/datum/reagent/mutationtoxin/jelly = 1, /datum/reagent/toxin/pestkiller = 1)
+
+/datum/chemical_reaction/mutationtoxin_pod
+	results = list(/datum/reagent/mutationtoxin/pod = 2)
+	required_reagents = list(/datum/reagent/mutationtoxin/jelly = 1, /datum/reagent/plantnutriment/eznutriment = 1)
+
+/datum/chemical_reaction/mutationtoxin_skeleton
+	results = list(/datum/reagent/mutationtoxin/skeleton = 2)
+	required_reagents = list(/datum/reagent/mutationtoxin/jelly = 1, /datum/reagent/toxin/bonehurtingjuice = 1)
+
+/datum/chemical_reaction/mutationtoxin_plasma
+	results = list(/datum/reagent/mutationtoxin/plasma = 2)
+	required_reagents = list(/datum/reagent/mutationtoxin/jelly = 1, /datum/reagent/oxygen = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Make unobtainable mutation toxins obtainable, they are all made by mixing a reagent with standard xenobio mutation toxin made from green slime
Moths - Cellulose fiber (Cloth)
Felinids - Liquid Gibs (Liquid gibs is what is require to grow cats in cytology)
Flies - Pest Killer (From botany spray)
Podmen - EZ nutrient (Plants like this)
Skeleton - Bone hurting juice (oof ouch my bones)
Plasmaman - Oxygen (Plasma and oxygen are friends)


## Why It's Good For The Game

Allows you to easily return back to your chosen race after it gets changed. Also you can shoot people with felinid mutation toxin,

## Changelog
:cl:
add: recipes for the mutation toxins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
