### PR TITLE
Voidtech office

### DIFF
--- a/ModularBungalow/bungalowWeapons/revolver.dm
+++ b/ModularBungalow/bungalowWeapons/revolver.dm
@@ -1,0 +1,20 @@
+//Chiappa Rhino
+/obj/item/gun/ballistic/revolver/rhino
+	name = "Chiappa Rhino"
+	desc = "A special pistol made for the captain, chambered in .38"
+	icon_state = "rhino"
+	icon = 'ModularBungalow/zbungalowicons/kirie_stuff/kiriepistols.dmi'
+	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev38
+	initial_caliber = CALIBER_38
+	fire_sound = 'sound/weapons/gun/revolver/shot_alt.ogg'
+	load_sound = 'sound/weapons/gun/revolver/load_bullet.ogg'
+	eject_sound = 'sound/weapons/gun/revolver/empty.ogg'
+	vary_fire_sound = FALSE
+	fire_sound_volume = 90
+	dry_fire_sound = 'sound/weapons/gun/revolver/dry_fire.ogg'
+	casing_ejector = FALSE
+	internal_magazine = TRUE
+	bolt_type = BOLT_TYPE_NO_BOLT
+	tac_reloads = FALSE
+	spin_delay = 10
+	recent_spin = 0

--- a/ModularTegustation/tegu_jobs/Voidtech/voidtech.dm
+++ b/ModularTegustation/tegu_jobs/Voidtech/voidtech.dm
@@ -44,8 +44,3 @@
 /obj/effect/landmark/start/voidtech
 	name = "Void Technician"
 	icon_state = "Station Engineer"
-
-/obj/effect/landmark/start/station_engineer/Initialize()
-	. = ..()
-	var/turf/T = get_turf(src)
-	new /obj/effect/landmark/start/voidtech(T)

--- a/ModularTegustation/tegu_jobs/Voidtech/voidtech.dm
+++ b/ModularTegustation/tegu_jobs/Voidtech/voidtech.dm
@@ -43,4 +43,4 @@
 //Spawn Point
 /obj/effect/landmark/start/voidtech
 	name = "Void Technician"
-	icon_state = "Station Engineer"
+	icon_state = "Void Technician"

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -37814,6 +37814,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bzP" = (
@@ -37843,6 +37844,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bzS" = (
@@ -37859,6 +37861,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bzT" = (
@@ -40175,6 +40178,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bDG" = (
@@ -40227,6 +40231,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bDN" = (
@@ -64365,21 +64370,15 @@
 "cxP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cxR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port)
+/obj/structure/falsewall/reinforced,
+/turf/open/floor/plating,
+/area/engine/storage)
 "cxT" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
@@ -65815,40 +65814,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/storage)
-"cAW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/flashlight,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/maintenance/port)
-"cAX" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"cAY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/loot_site_spawner,
-/turf/open/floor/plasteel,
-/area/maintenance/port)
 "cAZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/turf_decal/delivery,
-/obj/structure/tank_holder/emergency_oxygen,
-/turf/open/floor/plasteel,
-/area/maintenance/port)
+/obj/structure/falsewall/reinforced,
+/turf/closed/wall,
+/area/engine/storage)
 "cBa" = (
 /obj/item/kirbyplants/random,
 /obj/structure/extinguisher_cabinet{
@@ -66706,34 +66675,36 @@
 /area/engine/storage)
 "cCC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/blobstart,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 8
 	},
+/obj/item/storage/toolbox/electrical,
 /turf/open/floor/plasteel,
-/area/maintenance/port)
+/area/engine/storage)
 "cCD" = (
-/obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/bot,
+/obj/item/folder/blue,
 /turf/open/floor/plasteel,
-/area/maintenance/port)
+/area/engine/storage)
 "cCE" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel,
+/area/engine/storage)
+"cCF" = (
+/obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/table/reinforced,
+/obj/machinery/light{
 	dir = 4
 	},
+/obj/item/modular_computer/laptop/preset,
 /turf/open/floor/plasteel,
-/area/maintenance/port)
-"cCF" = (
-/obj/effect/turf_decal/bot,
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/maintenance/port)
+/area/engine/storage)
 "cCG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -67573,57 +67544,23 @@
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "cEj" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/maintenance/port)
-"cEk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/xeno_spawn,
-/obj/effect/turf_decal/tile/yellow{
+/area/engine/storage)
+"cEl" = (
+/obj/structure/chair/comfy/black{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/landmark/start/voidtech,
+/turf/open/floor/plasteel,
+/area/engine/storage)
+"cEm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/port)
-"cEl" = (
-/obj/effect/landmark/blobstart,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port)
-"cEm" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port)
+/area/engine/storage)
 "cEn" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -68576,53 +68513,21 @@
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "cFY" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/rglass{
-	amount = 50;
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/item/stock_parts/cell/emproof{
-	pixel_x = 1;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "cFZ" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/port)
-"cGa" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
+/area/engine/storage)
 "cGb" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
 	},
+/obj/effect/landmark/start/voidtech,
 /turf/open/floor/plasteel,
-/area/maintenance/port)
-"cGc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/maintenance/port)
+/area/engine/storage)
 "cGd" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -69263,50 +69168,46 @@
 /area/engine/storage)
 "cHu" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/rods/fifty,
-/obj/item/wrench,
-/obj/item/storage/box/lights/mixed,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/rglass{
+	amount = 50;
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/obj/item/stock_parts/cell/emproof{
+	pixel_x = 1;
+	pixel_y = 3
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "cHv" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/engine/storage)
 "cHw" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/rods/fifty,
-/obj/item/wrench,
-/obj/item/storage/box/lights/mixed,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/suit_storage_unit,
 /turf/open/floor/plasteel,
-/area/maintenance/port)
+/area/engine/storage)
 "cHx" = (
-/obj/structure/rack,
-/obj/item/book/manual/wiki/engineering_hacking{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/book/manual/wiki/engineering_guide,
-/obj/item/book/manual/wiki/engineering_construction{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/machinery/suit_storage_unit,
+/turf/open/floor/plasteel,
+/area/engine/storage)
 "cHy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage)
 "cHz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -86642,6 +86543,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"dqZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage)
 "drf" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -106512,6 +106421,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
+"gXu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/falsewall/reinforced,
+/turf/open/floor/plasteel,
+/area/engine/storage)
 "had" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -108169,6 +108085,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"kAW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage)
 "kDh" = (
 /obj/structure/table/reinforced,
 /obj/structure/displaycase/forsale/kitchen,
@@ -108188,6 +108122,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
 /area/vacant_room/commissary)
+"kFm" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Void Technician's Office";
+	req_access_txt = "32"
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage)
 "kFx" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -108536,6 +108478,12 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"lqc" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel,
+/area/engine/storage)
 "lrz" = (
 /obj/machinery/door/airlock/medical{
 	name = "Psychology";
@@ -110016,6 +109964,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/prison)
+"oBX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "oCS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -110540,6 +110498,14 @@
 "pxG" = (
 /turf/closed/wall,
 /area/medical/pharmacy)
+"pza" = (
+/obj/structure/closet/crate,
+/obj/item/survivalcapsule,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plasteel,
+/area/engine/storage)
 "pzj" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -112015,6 +111981,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"sCm" = (
+/obj/structure/table/reinforced,
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/engine/storage)
 "sDg" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -112508,6 +112482,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
+"tyM" = (
+/obj/structure/falsewall/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/closed/wall,
+/area/engine/storage)
 "tzj" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -113315,10 +113296,13 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "vec" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/tank_holder/emergency_oxygen,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/machinery/suit_storage_unit,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage)
 "vjn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hydroponics/constructable,
@@ -142374,7 +142358,7 @@ cwo
 cwo
 cwo
 cwo
-cwo
+kFm
 cwo
 cwo
 cKd
@@ -142626,14 +142610,14 @@ cnI
 cnI
 cnI
 cnI
-cxN
-cxN
-cxO
+ceb
+cea
+cxR
 cCC
-cxN
+cFY
 cFZ
-cxN
-cxO
+dqZ
+cxR
 oxa
 cMY
 cNd
@@ -142883,14 +142867,14 @@ csa
 ctE
 cvd
 cnI
-cxO
-caE
-caE
-caE
-caE
-caE
-caE
-caE
+ceb
+ceb
+cAZ
+lqc
+cEl
+kAW
+pza
+cAZ
 oxa
 cMY
 xmf
@@ -143141,13 +143125,13 @@ ctF
 cve
 cnI
 cxP
-caE
-cAW
+ceb
+cAZ
 cCD
 cEj
-cGa
+cHy
 cHv
-caE
+cAZ
 cKf
 cMY
 cNd
@@ -143397,14 +143381,14 @@ csc
 ctG
 cvf
 cnI
-cxN
-caE
-cAX
-ceb
-cEk
+cea
+cea
+cAZ
+sCm
+cFY
 cGb
 cHw
-caE
+cAZ
 cKa
 cMY
 vHZ
@@ -143654,14 +143638,14 @@ csd
 ctH
 cvg
 cnI
-cxO
-caE
-cAY
+ceb
+ceb
+cAZ
 cCE
 cEl
-cGc
+cHy
 cHx
-caE
+cAZ
 oxa
 cMY
 cNg
@@ -143911,14 +143895,14 @@ cse
 cnI
 cnI
 cnI
-cxR
-caE
+cjq
+cea
 cAZ
 cCF
 cEm
 cHy
 vec
-caE
+cAZ
 cKo
 cMY
 cNd
@@ -144168,14 +144152,14 @@ cLs
 ctI
 cfU
 cea
-cxN
-caE
-caE
-caE
-cEn
-caE
-caE
-caE
+cea
+cea
+cAZ
+cAZ
+gXu
+tyM
+cAZ
+cAZ
 oxa
 cMY
 vHZ
@@ -144430,7 +144414,7 @@ czB
 ddM
 cCG
 cEo
-ddM
+oBX
 cHz
 ddO
 cKi

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -13786,7 +13786,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/landmark/start/station_engineer,
+/obj/effect/landmark/start/voidtech,
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "axd" = (
@@ -21693,6 +21693,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer2{
 	dir = 4
 	},
+/obj/effect/landmark/start/voidtech,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "aKr" = (
@@ -36838,6 +36839,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-05"
 	},
+/obj/effect/landmark/start/voidtech,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bhy" = (
@@ -37409,6 +37411,7 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "biw" = (
@@ -45458,6 +45461,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bvo" = (
@@ -45675,6 +45679,7 @@
 "bvF" = (
 /obj/structure/chair/office,
 /obj/structure/cable,
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bvG" = (
@@ -47171,6 +47176,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "byw" = (
@@ -48485,6 +48491,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bAB" = (
@@ -48566,6 +48573,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bAJ" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -18976,12 +18976,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aWu" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Void Technician's Office";
+	req_one_access_txt = "10;24"
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/engine/storage_shared)
 "aWv" = (
 /turf/closed/wall,
 /area/storage/tech)
@@ -19091,10 +19095,12 @@
 	},
 /area/engine/engineering)
 "aWH" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/dark,
+/area/engine/storage_shared)
 "aWK" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -24575,12 +24581,14 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bjb" = (
 /obj/structure/chair/office{
 	dir = 1
 	},
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bjc" = (
@@ -24591,6 +24599,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bje" = (
@@ -24598,6 +24607,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bjf" = (
@@ -51558,12 +51568,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"cXI" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "cXR" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -51581,10 +51585,9 @@
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "cYj" = (
-/obj/structure/closet/firecloset,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/suit_storage_unit,
+/turf/open/floor/plasteel/dark,
+/area/engine/storage_shared)
 "cYE" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/tile/yellow{
@@ -52597,11 +52600,13 @@
 /turf/open/space,
 /area/space/nearstation)
 "dgi" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/effect/landmark/start/voidtech,
+/turf/open/floor/plasteel/dark,
+/area/engine/storage_shared)
 "dgj" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -59296,6 +59301,16 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"gJo" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Airlock";
+	req_access_txt = "24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "gJs" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -60708,6 +60723,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"hUG" = (
+/turf/closed/wall/r_wall,
+/area/engine/storage_shared)
 "hVd" = (
 /obj/effect/turf_decal/box/corners,
 /obj/effect/turf_decal/box/corners{
@@ -61955,6 +61973,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"jan" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/engine/storage_shared)
 "jbB" = (
 /obj/effect/spawner/lootdrop/prison_contraband,
 /obj/structure/closet/crate,
@@ -62258,6 +62280,8 @@
 	pixel_x = 27;
 	pixel_y = 29
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "jnW" = (
@@ -63986,16 +64010,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "kyG" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_one_access_txt = "10;24"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/closed/indestructible/reinforced,
+/area/engine/engineering)
 "kzn" = (
 /obj/machinery/door/airlock/external{
 	name = "Departure Lounge Airlock"
@@ -66713,11 +66732,11 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "mEI" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/engine/storage_shared)
 "mGc" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -66950,6 +66969,10 @@
 /obj/effect/landmark/start/head_of_security,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hos)
+"mPM" = (
+/obj/effect/landmark/start/voidtech,
+/turf/open/floor/plasteel/dark,
+/area/engine/storage_shared)
 "mQI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -67263,6 +67286,9 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/voidtech,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "neP" = (
@@ -67477,6 +67503,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"noO" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "npx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -67725,9 +67760,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
 "nzS" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/storage_shared)
 "nAR" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6
@@ -67930,6 +67969,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"nHj" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "nHO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -69600,10 +69651,12 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "oQH" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/engine/storage_shared)
 "oRD" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/white,
@@ -71560,19 +71613,9 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "qgQ" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "qhe" = (
@@ -78892,6 +78935,7 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},
@@ -80250,13 +80294,8 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "wJc" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/floor/plasteel/dark,
+/area/engine/storage_shared)
 "wKj" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -81811,11 +81850,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "xQP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/table/reinforced,
+/obj/item/modular_computer/laptop/preset,
+/turf/open/floor/plasteel/dark,
+/area/engine/storage_shared)
 "xRg" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -82242,6 +82280,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"ycm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/storage_shared)
 "ycH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -125265,12 +125309,12 @@ deD
 uIw
 dfT
 aVe
-alq
-alq
-alq
-alq
-alq
-atm
+owR
+owR
+owR
+owR
+owR
+hUG
 bhW
 bjL
 bls
@@ -125780,11 +125824,11 @@ sUG
 dfT
 kyG
 xQP
-apc
-aqq
-apc
+jan
+ycm
+mPM
 wJc
-atm
+hUG
 bfZ
 bif
 bfY
@@ -126036,12 +126080,12 @@ djt
 oos
 cXz
 aVe
-atm
-alr
-alr
-cXI
+hUG
+vyS
+vyS
 cYj
-atm
+cYj
+hUG
 qrL
 bjR
 pXE
@@ -126295,10 +126339,10 @@ dfR
 dga
 dgd
 dgj
-alr
-alr
-atm
-atm
+vyS
+vyS
+hUG
+hUG
 atm
 kle
 gZM
@@ -128335,7 +128379,7 @@ aaa
 aaa
 aaa
 axY
-axY
+noO
 axY
 axY
 axY
@@ -128591,9 +128635,9 @@ aaf
 aaa
 aaa
 aaa
-aaa
-aaf
-aaa
+axY
+nHj
+axY
 aaf
 aaa
 aaa
@@ -128848,9 +128892,9 @@ aaf
 aaa
 aaa
 aaa
-aaa
-aaf
-aaa
+axY
+gJo
+axY
 aaf
 aaa
 aaa

--- a/_maps/map_files/PackedStation/PackedStation.dmm
+++ b/_maps/map_files/PackedStation/PackedStation.dmm
@@ -169,6 +169,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aax" = (
@@ -7187,6 +7188,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aoU" = (
@@ -15129,6 +15131,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/landmark/start/voidtech,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "aEA" = (
@@ -17447,6 +17450,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aTj" = (
@@ -20095,6 +20099,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/effect/landmark/start/secretary,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "cTX" = (
@@ -27471,6 +27476,20 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"mcL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/landmark/start/voidtech,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "mdn" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -31955,6 +31974,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/landmark/start/voidtech,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "rMH" = (
@@ -66078,7 +66098,7 @@ qhg
 aEq
 aEs
 aEz
-jzw
+mcL
 rMk
 xDg
 qhg

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -193,6 +193,10 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	name = "Cyborg"
 	icon_state = "Cyborg"
 
+/obj/effect/landmark/start/secretary
+	name = "Secretary"
+	icon_state = "Secretary"
+
 /obj/effect/landmark/start/ai
 	name = "AI"
 	icon_state = "AI"


### PR DESCRIPTION
## About The Pull Request

Adds an Office to Void Technicians, and fixes spawn points.

## Why It's Good For The Game

This is a Fix, and makes Voidtech feel less tacked on.

## Changelog
:cl:
add: Added Voidtech offices to Meta and Delta
fix: fixes spawnpoints for Voidtech adn Secretary
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
