### PR TITLE
Changes the nukie sniper with a laser one

### DIFF
--- a/ModularBungalow/SecuritySpecialist/specialist.dm
+++ b/ModularBungalow/SecuritySpecialist/specialist.dm
@@ -22,8 +22,7 @@
 	desc = "A large duffel bag containing a sniper rifle loaded in 50 cal and a magazine of sleeping shots. Comes with thermal goggles"
 
 /obj/item/storage/backpack/duffelbag/sec/spec/PopulateContents()
-	new /obj/item/gun/ballistic/automatic/sniper_rifle(src)
-	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
+	new /obj/item/gun/energy/sniper/security(src)
 	new /obj/item/clothing/glasses/thermal(src)
 
 

--- a/ModularBungalow/bungalowWeapons/energy.dm
+++ b/ModularBungalow/bungalowWeapons/energy.dm
@@ -46,7 +46,7 @@
 
 //Disabler Beam
 /obj/projectile/beam/disabler/beam
-	name = "heavy disabler beam"
+	name = "disabler beam"
 	icon_state = "omnilaser"
 	hitscan = TRUE
 	damage = 20
@@ -64,6 +64,7 @@
 	impact_light_range = 2.5
 	impact_light_color_override = COLOR_CYAN
 
+
 // Svet's Disabler
 /obj/item/gun/energy/disabler/svet_disabler
 	name = "Brass Ray"
@@ -79,3 +80,40 @@
 	flight_y_offset = 10
 	selfcharge = 1
 	w_class = WEIGHT_CLASS_SMALL
+
+
+//Wetwork Energy Sniper
+/obj/item/gun/energy/sniper/security
+	name = "wetwork sniper rifle"
+	desc = "An advanced piece of weaponry forged by NT to terminate troublemakers."
+	ammo_type = list(/obj/item/ammo_casing/energy/sniper, /obj/item/ammo_casing/energy/sniper/disable)
+
+/obj/item/gun/energy/sniper/security/Initialize()
+	. = ..()
+	fire_delay = 30
+
+/obj/item/ammo_casing/energy/sniper/disable
+	projectile_type = /obj/projectile/beam/laser/sniper/disable
+	select_name = "anti-personnel"
+	fire_sound = 'sound/weapons/lasercannonfire.ogg'
+
+/obj/projectile/beam/laser/sniper/disable
+	name = "heavy disabler beam"
+	icon_state = "omnilaser"
+	light_color = COLOR_CYAN
+	hitscan = TRUE
+	damage = 80
+	damage_type = STAMINA
+	flag = ENERGY
+	hitsound = 'sound/weapons/tap.ogg'
+	eyeblur = 0
+	hitscan_light_intensity = 2
+	hitscan_light_range = 0.75
+	hitscan_light_color_override = COLOR_CYAN
+	muzzle_flash_intensity = 4
+	muzzle_flash_range = 2
+	muzzle_flash_color_override = COLOR_CYAN
+	impact_light_intensity = 6
+	impact_light_range = 2.5
+	impact_light_color_override = COLOR_CYAN
+

--- a/code/modules/projectiles/guns/energy/sniper.dm
+++ b/code/modules/projectiles/guns/energy/sniper.dm
@@ -9,7 +9,7 @@
 	fire_sound = 'sound/weapons/laser3.ogg'
 	fire_sound_volume = 90
 	vary_fire_sound = FALSE
-	pin = null
+	pin = /obj/item/firing_pin
 	cell_type = /obj/item/stock_parts/cell/energy_sniper
 	weapon_weight = WEAPON_HEAVY
 	can_flashlight = FALSE
@@ -27,7 +27,7 @@
 	fire_delay = 30
 
 /obj/item/gun/energy/sniper/pin
-	pin = /obj/item/firing_pin
+	name = "NT energy rifle"
 
 /obj/item/ammo_casing/energy/sniper
 	projectile_type = /obj/projectile/beam/laser/sniper

--- a/code/modules/ruins/lavalandruin_code/techcult.dm
+++ b/code/modules/ruins/lavalandruin_code/techcult.dm
@@ -185,7 +185,7 @@
 	suit = null
 	gloves = /obj/item/clothing/gloves/combat
 	glasses = /obj/item/clothing/glasses/hud/diagnostic/night
-	r_hand = /obj/item/gun/energy/sniper/pin
+	r_hand = /obj/item/gun/energy/sniper
 	back = /obj/item/storage/backpack/cultpack
 	backpack_contents = list(/obj/item/storage/book/bible/omnissiah, /obj/item/book/granter/spell/omnissiah, /obj/item/organ/heart/cybernetic/tier4)
 
@@ -335,7 +335,7 @@
 	id = "mars_tech"
 	display_name = "Marsian Technology"
 	description = "A complicated technology, used by Marsian scientists and soldiers alike."
-	boost_item_paths = list(/obj/item/gun/energy/sniper, /obj/item/gun/energy/sniper/pin, /obj/item/organ/heart/cybernetic/tier4, /obj/item/organ/lungs/cybernetic/tier4, /obj/item/organ/cyberimp/chest/reviver/plus, /obj/item/organ/cyberimp/arm/surgery/plus)
+	boost_item_paths = list(/obj/item/gun/energy/sniper, /obj/item/gun/energy/sniper, /obj/item/organ/heart/cybernetic/tier4, /obj/item/organ/lungs/cybernetic/tier4, /obj/item/organ/cyberimp/chest/reviver/plus, /obj/item/organ/cyberimp/arm/surgery/plus)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	hidden = TRUE
 


### PR DESCRIPTION
## About The Pull Request

Swaps out the nukie sniper for a special laser disabler and laser one.

## Why It's Good For The Game

Stops security from having 1-hit de-limbing weapons while still having wetwork as an option.

## Changelog
:cl:
add: Added Security laser sniper
tweak: Changed the security kit to have Laser sniper instead of ballistics one
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
