### PR TITLE
Gives engineers, and only engineers a drill

### DIFF
--- a/ModularTegustation/tegu_jobs/Voidtech/voidtech.dm
+++ b/ModularTegustation/tegu_jobs/Voidtech/voidtech.dm
@@ -25,7 +25,7 @@
 	name = "Void Technician"
 	jobtype = /datum/job/tegu/voidtech
 
-	belt = /obj/item/storage/belt/utility/full/engi
+	belt = /obj/item/storage/belt/utility/full
 	l_pocket = /obj/item/pda/engineering
 	ears = /obj/item/radio/headset/subspace/void
 	uniform = /obj/item/clothing/under/rank/engineering/void

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -99,8 +99,7 @@
 	new /obj/item/stack/cable_coil(src)
 
 /obj/item/storage/belt/utility/full/engi/PopulateContents()
-	new /obj/item/screwdriver(src)
-	new /obj/item/wrench(src)
+	new /obj/item/screwdriver/power(src)
 	new /obj/item/weldingtool/largetank(src)
 	new /obj/item/crowbar(src)
 	new /obj/item/wirecutters(src)


### PR DESCRIPTION
## About The Pull Request
Gives engineers a drill in their belt

## Why It's Good For The Game
It makes sense for lore reasons. everyone else, VTs and Atmos, still get their normal belts

## Changelog
:cl:
tweak: makes this make sense in the year 2550
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
