### PR TITLE
Cloner malfunctions

### DIFF
--- a/ModularBungalow/Cloning/circuits.dm
+++ b/ModularBungalow/Cloning/circuits.dm
@@ -11,5 +11,6 @@
 		/obj/item/stack/cable_coil = 2,
 		/obj/item/stock_parts/scanning_module = 2,
 		/obj/item/stock_parts/manipulator = 2,
-		/obj/item/stack/sheet/glass = 1)
+		/obj/item/stack/sheet/glass = 1,
+		/obj/item/stock_parts/micro_laser = 1)
 

--- a/ModularBungalow/Cloning/machine.dm
+++ b/ModularBungalow/Cloning/machine.dm
@@ -41,6 +41,10 @@
 	fair_market_price = 5 // He nodded, because he knew I was right. Then he swiped his credit card to pay me for arresting him.
 	payment_department = ACCOUNT_MED
 
+	//Variables for malfunction chances
+	var/failchance
+	var/successchance
+
 /obj/machinery/clonepod/Initialize()
 	. = ..()
 
@@ -73,6 +77,9 @@
 		efficiency += S.rating
 	for(var/obj/item/stock_parts/manipulator/P in component_parts)
 		speed_coeff += P.rating
+	for(var/obj/item/stock_parts/micro_laser/M in component_parts)
+		failchance = 25 / M.rating
+		successchance = 100 - failchance
 	heal_level = (efficiency * 15) + 10
 	if(heal_level < MINIMUM_HEAL_LEVEL)
 		heal_level = MINIMUM_HEAL_LEVEL
@@ -293,6 +300,8 @@
 			progress += (100 - MINIMUM_HEAL_LEVEL)
 			var/milestone = CLONE_INITIAL_DAMAGE / flesh_number
 			var/installed = flesh_number - unattached_flesh.len
+			if(prob(failchance*0.1))
+				traumatize(mob_occupant)
 
 			if((progress / milestone) >= installed)
 				// attach some flesh
@@ -300,10 +309,14 @@
 				if(isorgan(I))
 					var/obj/item/organ/O = I
 					O.organ_flags &= ~ORGAN_FROZEN
-					O.Insert(mob_occupant)
+					if(prob(successchance))
+						O.Insert(mob_occupant)
+						return
 				else if(isbodypart(I))
 					var/obj/item/bodypart/BP = I
-					BP.attach_limb(mob_occupant)
+					if(prob(successchance))
+						BP.attach_limb(mob_occupant)
+						return
 
 			use_power(7500) //This might need tweaking.
 
@@ -318,10 +331,14 @@
 				if(isorgan(i))
 					var/obj/item/organ/O = i
 					O.organ_flags &= ~ORGAN_FROZEN
-					O.Insert(mob_occupant)
+					if(prob(successchance))
+						O.Insert(mob_occupant)
+						return
 				else if(isbodypart(i))
 					var/obj/item/bodypart/BP = i
-					BP.attach_limb(mob_occupant)
+					if(prob(successchance))
+						BP.attach_limb(mob_occupant)
+						return
 
 			go_out()
 			log_cloning("[key_name(mob_occupant)] completed cloning cycle in [src] at [AREACOORD(src)].")

--- a/ModularBungalow/Cloning/trauma.dm
+++ b/ModularBungalow/Cloning/trauma.dm
@@ -1,0 +1,11 @@
+/obj/machinery/clonepod/proc/traumatize(mob/living/carbon/human/H)
+	var/resistance = pick(
+		50;TRAUMA_RESILIENCE_BASIC,
+		30;TRAUMA_RESILIENCE_SURGERY)
+
+	var/trauma_type = pickweight(list(
+		BRAIN_TRAUMA_MILD = 60,
+		BRAIN_TRAUMA_SEVERE = 30
+	))
+
+	H.gain_trauma_type(trauma_type, resistance)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3381,6 +3381,7 @@
 #include "ModularBungalow\Cloning\machine.dm"
 #include "ModularBungalow\Cloning\negative_mood.dm"
 #include "ModularBungalow\Cloning\traits.dm"
+#include "ModularBungalow\Cloning\trauma.dm"
 #include "ModularBungalow\Clothing\suit.dm"
 #include "ModularBungalow\Drinks_and_food\bottles_code.dm"
 #include "ModularBungalow\Drinks_and_food\drinks_chemical_reactiong.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cloners now require micro-lasers, with the incentive to upgrade being errors.
Each limb and organ has a base 25% chance to not spawn on t1 lasers, and it has a 2.5% chance to spawn a mild or severe trauma.
Chances decrease with tier, having it be 5% on organs and limbs and 0.5% on traumas at t5.

## Why It's Good For The Game

Cloners are a bit busted, this should make it so doctors can't just clone them, chuck them in cryo and be done with it. However, the cloner is still a viable option in emergencies such as gibbing or
 excessive brute/burn damage

## Changelog
:cl:
add: cloner malfunctions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
