### PR TITLE
 Atmospherics Envirogloves are no longer insulated. 

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -115,7 +115,6 @@
 	name = "atmos envirogloves"
 	icon_state = "atmosplasma"
 	inhand_icon_state = "atmosplasma"
-	siemens_coefficient = 0
 
 /obj/item/clothing/gloves/color/plasmaman/explorer
 	name = "explorer envirogloves"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/58319 over. I'll just quote that PR for the rest of this one:
This PR makes it so that the Plasmamen Atmospherics Envirogloves aren't insulated.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The rest of the engineering envirogloves are insulated because both engineers and CE's normally use insuls, however, atmos techs shouldn't be getting insuls, so this seems like an oversight.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

fix: Atmospherics Envirogloves are no longer insulated.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
