### PR TITLE
Buffs Biosuits and makes them usable over Hardsuits (and the VT hardsuit)

### DIFF
--- a/ModularTegustation/tegu_jobs/Voidtech/voidtechClothing.dm
+++ b/ModularTegustation/tegu_jobs/Voidtech/voidtechClothing.dm
@@ -34,9 +34,9 @@
 	inhand_icon_state = "void_hardsuit"
 	lefthand_file = 'ModularTegustation/Teguicons/kirie_stuff/left.dmi'
 	righthand_file = 'ModularTegustation/Teguicons/kirie_stuff/right.dmi'
-	armor = list(MELEE = 20, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 10, BIO = 100, RAD = 15, FIRE = 60, ACID = 30, WOUND = 10)
+	armor = list(MELEE = 20, BULLET = 10, LASER = 10, ENERGY = 5, BOMB = 10, BIO = 100, RAD = 15, FIRE = 60, ACID = 30, WOUND = 10)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/voidtech
-	slowdown = 0.35
+	slowdown = 0.25
 
 
 //Special Subspace Headset
@@ -55,4 +55,4 @@
 	name = "void technicians radio encryption key"
 	icon_state = "eng_cypherkey"
 	channels = list(RADIO_CHANNEL_SCIENCE = 1, RADIO_CHANNEL_ENGINEERING = 1)
-	
+

--- a/ModularTegustation/tegu_locker_overwrites.dm
+++ b/ModularTegustation/tegu_locker_overwrites.dm
@@ -19,7 +19,7 @@
 	new /obj/item/clothing/shoes/sneakers/brown/digitigrade(src)
 	new /obj/item/clothing/suit/hooded/wintercoat/medical/head(src)
 	new /obj/item/clothing/head/cmoberet(src)
-	new /obj/item/gun/syringe/rapidsyringe(src)
+	new /obj/item/gun/syringe/rifle(src)
 	new /obj/item/storage/lockbox/medal/cmo(src)
 	. = ..()
 

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -5,10 +5,11 @@
 	desc = "A hood that protects the head and face from biological contaminants."
 	permeability_coefficient = 0.01
 	clothing_flags = THICKMATERIAL | BLOCK_GAS_SMOKE_EFFECT | SNUG_FIT
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 100, RAD = 80, FIRE = 30, ACID = 100)
+	armor = list(MELEE = 0, BULLET = 0, LASER = 20,ENERGY = 0, BOMB = 0, BIO = 100, RAD = 80, FIRE = 30, ACID = 100)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDEFACE|HIDESNOUT
-	resistance_flags = ACID_PROOF
+	resistance_flags = ACID_PROOF | FIRE_PROOF
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
+	max_heat_protection_temperature = 500
 
 /obj/item/clothing/suit/bio_suit
 	name = "bio suit"
@@ -20,13 +21,14 @@
 	permeability_coefficient = 0.01
 	clothing_flags = THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	slowdown = 0.5
+	slowdown = 0.35
 	allowed = list(/obj/item/tank/internals, /obj/item/reagent_containers/dropper, /obj/item/flashlight/pen, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray, /obj/item/reagent_containers/glass/beaker)
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 100, RAD = 80, FIRE = 30, ACID = 100)
+	armor = list(MELEE = 0, BULLET = 0, LASER = 20,ENERGY = 0, BOMB = 0, BIO = 100, RAD = 80, FIRE = 100, ACID = 100)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	strip_delay = 70
 	equip_delay_other = 70
-	resistance_flags = ACID_PROOF
+	resistance_flags = ACID_PROOF | FIRE_PROOF
+	max_heat_protection_temperature = 500
 
 //Standard biosuit, orange stripe
 /obj/item/clothing/head/bio_hood/general
@@ -46,11 +48,11 @@
 
 //Security biosuit, grey with red stripe across the chest
 /obj/item/clothing/head/bio_hood/security
-	armor = list(MELEE = 25, BULLET = 15, LASER = 25, ENERGY = 35, BOMB = 25, BIO = 100, RAD = 80, FIRE = 30, ACID = 100)
+	armor = list(MELEE = 25, BULLET = 15, LASER = 25, ENERGY = 35, BOMB = 25, BIO = 100, RAD = 80, FIRE = 100, ACID = 100)
 	icon_state = "bio_security"
 
 /obj/item/clothing/suit/bio_suit/security
-	armor = list(MELEE = 25, BULLET = 15, LASER = 25, ENERGY = 35, BOMB = 25, BIO = 100, RAD = 80, FIRE = 30, ACID = 100)
+	armor = list(MELEE = 25, BULLET = 15, LASER = 25, ENERGY = 35, BOMB = 25, BIO = 100, RAD = 80, FIRE = 100, ACID = 100)
 	icon_state = "bio_security"
 
 /obj/item/clothing/suit/bio_suit/security/Initialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buffs biosuits by doing the following:
Increases Laser resistance to 20%, from 0. (They're bright white fucking armor, generally very reflective they should be able to help a little bit with armor)
Reduces slowdown from 1 to 0.35
increases heat resistance from 0 to 500K

VT hardsuit slowdown decreased from 0.35 to 0.25
Increases bullet and laser resistance by 5 each.

Also the CMO finally gets their gun.

## Why It's Good For The Game
Finally Biosuits are fucking worth using.

## Changelog
:cl:
balance: Buffed Biosuit
fix: finally gave the CMO their rifle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
