### PR TITLE
Adding back budget cards in physical item

### DIFF
--- a/ModularBungalow/budgetcard/deptartementcard.dm
+++ b/ModularBungalow/budgetcard/deptartementcard.dm
@@ -1,0 +1,29 @@
+/obj/item/card/id/departmental_budget/civ
+	department_ID = ACCOUNT_CIV
+	department_name = ACCOUNT_CIV_NAME
+	icon_state = "civ_budget"
+
+/obj/item/card/id/departmental_budget/eng
+	department_ID = ACCOUNT_ENG
+	department_name = ACCOUNT_ENG_NAME
+	icon_state = "eng_budget"
+
+/obj/item/card/id/departmental_budget/sci
+	department_ID = ACCOUNT_SCI
+	department_name = ACCOUNT_SCI_NAME
+	icon_state = "sci_budget"
+
+/obj/item/card/id/departmental_budget/med
+	department_ID = ACCOUNT_MED
+	department_name = ACCOUNT_MED_NAME
+	icon_state = "med_budget"
+
+/obj/item/card/id/departmental_budget/srv
+	department_ID = ACCOUNT_SRV
+	department_name = ACCOUNT_SRV_NAME
+	icon_state = "srv_budget"
+
+/obj/item/card/id/departmental_budget/sec
+	department_ID = ACCOUNT_SEC
+	department_name = ACCOUNT_SEC_NAME
+	icon_state = "sec_budget"

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -26,6 +26,9 @@
 	new /obj/item/extinguisher/advanced(src)
 	new /obj/item/storage/photo_album/ce(src)
 	new /obj/item/storage/box/skillchips/engineering(src)
+	/* START EDIT BUNGALOW */
+	new /obj/item/card/id/departmental_budget/eng(src)
+	/* END EDIT BUNGALOW */
 
 /obj/structure/closet/secure_closet/engineering_electrical
 	name = "electrical supplies locker"

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -95,6 +95,9 @@
 	new /obj/item/wallframe/defib_mount(src)
 	new /obj/item/circuitboard/machine/techfab/department/medical(src)
 	new /obj/item/storage/photo_album/cmo(src)
+	/* START EDIT BUNGALOW */
+	new /obj/item/card/id/departmental_budget/med(src)
+	/* END EDIT BUNGALOW */
 
 /obj/structure/closet/secure_closet/spareparts
 	name = "\proper chief medical officer's wacky parts locker"

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -28,6 +28,9 @@
 	new /obj/item/circuitboard/machine/techfab/department/science(src)
 	new /obj/item/storage/photo_album/rd(src)
 	new /obj/item/storage/box/skillchips/science(src)
+	/* START EDIT BUNGALOW */
+	new /obj/item/card/id/departmental_budget/sci(src)
+	/* END EDIT BUNGALOW */
 
 
 /obj/structure/closet/secure_closet/cytology

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -63,7 +63,9 @@
 	new /obj/item/circuitboard/machine/techfab/department/service(src)
 	new /obj/item/storage/photo_album/hop(src)
 	new /obj/item/storage/lockbox/medal/hop(src)
-
+	/* START EDIT BUNGALOW */
+	new /obj/item/card/id/departmental_budget/srv(src)
+	/* END EDIT BUNGALOW */
 
 /obj/structure/closet/secure_closet/hos
 	name = "\proper head of security's locker"
@@ -98,6 +100,9 @@
 	new /obj/item/pinpointer/nuke(src)
 	new /obj/item/circuitboard/machine/techfab/department/security(src)
 	new /obj/item/storage/photo_album/hos(src)
+	/* START EDIT BUNGALOW */
+	new /obj/item/card/id/departmental_budget/sec(src)
+	/* END EDIT BUNGALOW */
 
 /obj/structure/closet/secure_closet/warden
 	name = "\proper warden's locker"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3394,6 +3394,7 @@
 #include "ModularBungalow\terry.dm"
 #include "ModularBungalow\altjobtitles\alt_titles.dm"
 #include "ModularBungalow\altjobtitles\outfits.dm"
+#include "ModularBungalow\budgetcard\deptartementcard.dm"
 #include "ModularBungalow\bungalowchemistry\bungalowmutation.dm"
 #include "ModularBungalow\bungalowchemistry\vaetoxinrecipes.dm"
 #include "ModularBungalow\bungalowWeapons\ballistics.dm"


### PR DESCRIPTION
## About The Pull Request
Head's closet spawn with their departemental budget  card in it.

It may be redundant considering you can spend your departemental budget trough your head's card.
But with a physical item, you can use these cards for machines like paystands, BEPIS or even buy things from vendors. You can also insert manually credits in this

## Why It's Good For The Game
More economical interractions and gimmicks.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added back departemental budgets cards ! 

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
