### PR TITLE
Tiny Cybersun tweaks

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -721,6 +721,10 @@
 	},
 /obj/item/language_manual/codespeak_manual/unlimited,
 /obj/effect/turf_decal/bot,
+/obj/item/stack/spacecash/c10000,
+/obj/item/stack/spacecash/c10000,
+/obj/item/stack/spacecash/c10000,
+/obj/item/stack/spacecash/c10000,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
 "bC" = (
@@ -1080,6 +1084,7 @@
 	dir = 6;
 	icon_state = "warningline"
 	},
+/obj/item/flashlight/lantern/syndicate,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
 "cl" = (
@@ -2386,9 +2391,15 @@
 /obj/structure/closet/crate/secure/gear{
 	req_one_access_txt = "150"
 	},
-/obj/effect/spawner/lootdrop/costume,
 /obj/effect/turf_decal/bot_red,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/syndicate,
+/obj/item/clothing/under/syndicate/camo,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/under/syndicate,
+/obj/item/clothing/under/syndicate/skirt,
+/obj/item/clothing/under/syndicate/skirt,
+/obj/item/clothing/under/syndicate/sniper,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "ew" = (
@@ -2793,8 +2804,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "NC" = (
-/turf/template_noop,
-/area/ruin/unpowered/no_grav)
+/turf/closed/wall/mineral/plastitanium/interior,
+/area/ruin/space/has_grav/syndicate_forgotten_ship)
 
 (1,1,1) = {"
 aY
@@ -3707,8 +3718,8 @@ al
 bZ
 ea
 dH
-bZ
-bZ
+NC
+NC
 bZ
 aY
 aY
@@ -4076,7 +4087,7 @@ bq
 bq
 ba
 ba
-NC
+aY
 aY
 aY
 aY
@@ -4107,15 +4118,15 @@ aY
 aY
 aY
 aY
-NC
+aY
 bq
 ba
 ba
 ba
 ba
 ba
-NC
-NC
+aY
+aY
 aY
 aY
 aY
@@ -4146,14 +4157,14 @@ aY
 aY
 aY
 aY
-NC
-NC
-NC
-NC
-NC
-NC
-NC
-NC
+aY
+aY
+aY
+aY
+aY
+aY
+aY
+aY
 aY
 aY
 aY

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -679,16 +679,19 @@
 	important_info = "Obey orders given by your captain. DO NOT let the ship fall into enemy hands."
 	outfit = /datum/outfit/syndicatespace/syndicrew
 	assignedrole = ROLE_SYNDICATE_CYBERSUN
+	var/assigned_antag = /datum/antagonist/cybersun // I need it because captain is a subtype of this.
 
 /datum/outfit/syndicatespace/syndicrew/post_equip(mob/living/carbon/human/H)
 	H.faction |= ROLE_SYNDICATE
 
 /obj/effect/mob_spawn/human/syndicatespace/special(mob/living/new_spawn)
 	new_spawn.grant_language(/datum/language/codespeak, TRUE, TRUE, LANGUAGE_MIND)
-	new_spawn.mind.add_antag_datum(/datum/antagonist/cybersun)
+	new_spawn.mind.add_antag_datum(assigned_antag)
 	var/policy = get_policy(assignedrole)
-	if(policy)
+	if(policy) // If admins have a policy set for the Cybersun.
 		to_chat(new_spawn, "<span class='bold'>[policy]</span>")
+	else // No policy set - show important_info instead.
+		to_chat(new_spawn, "<span class='bold'>[important_info]</span>")
 
 /obj/effect/mob_spawn/human/syndicatespace/captain
 	name = "Syndicate Ship Captain"
@@ -697,9 +700,7 @@
 	important_info = "Protect the ship and secret documents in your backpack with your own life."
 	outfit = /datum/outfit/syndicatespace/syndicrew/syndicaptain
 	assignedrole = ROLE_SYNDICATE_CYBERSUN_CAPTAIN
-
-/obj/effect/mob_spawn/human/syndicatespace/captain/special(mob/living/new_spawn)
-	new_spawn.mind.add_antag_datum(/datum/antagonist/cybersun/captain)
+	assigned_antag = /datum/antagonist/cybersun/captain
 
 /datum/outfit/syndicatespace/syndicaptain/post_equip(mob/living/carbon/human/H)
 	H.faction |= ROLE_SYNDICATE

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -94,7 +94,7 @@ GLOBAL_LIST_INIT(exp_jobsmap, list(
 GLOBAL_LIST_INIT(exp_specialmap, list(
 	EXP_TYPE_LIVING = list(), // all living mobs
 	EXP_TYPE_ANTAG = list(),
-	EXP_TYPE_SPECIAL = list("Lifebringer","Ash Walker","Exile","Servant Golem","Free Golem","Hermit","Translocated Vet","Escaped Prisoner","Hotel Staff","SuperFriend","Space Syndicate","Ancient Crew","Space Doctor","Space Bartender","Beach Bum","Skeleton","Zombie","Space Bar Patron","Lavaland Syndicate","Ghost Role"), // Ghost roles
+	EXP_TYPE_SPECIAL = list("Lifebringer","Ash Walker","Exile","Servant Golem","Free Golem","Hermit","Translocated Vet","Escaped Prisoner","Hotel Staff","SuperFriend","Space Syndicate",ROLE_SYNDICATE_CYBERSUN,ROLE_SYNDICATE_CYBERSUN_CAPTAIN,"Ancient Crew","Space Doctor","Space Bartender","Beach Bum","Skeleton","Zombie","Space Bar Patron","Lavaland Syndicate","Ghost Role"), // Ghost roles
 	EXP_TYPE_GHOST = list() // dead people, observers
 ))
 GLOBAL_PROTECT(exp_jobsmap)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Cybersun Crew and Captain will now show up in tracked playtime, under "Special" roles(ghost roles and such are all here).
- Cybersun roles will show important_info on spawn, if policy isn't set by the admins.
- Cybersun vault now has more stuff, most noticeably - 40.000 credits to make it a valuable target for the station, or extra funds for bribing/trading with the station in case you want to roleplay a bit.

## Why It's Good For The Game

- I mean, who doesn't want to flex their playtime?
- Admins should probably set policy themselves, but having nothing at all is just sad.
- As I said, le roleplay OR combat target for cargo. The credits are mechanically useless to the Cybersun, unless they use it for BEPIS, in which case they straight up give station free research, so there shouldn't be many balance concerns.
