### PR TITLE
Replaces 4 rad collectors on Meta with Tesla Coils

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -52255,12 +52255,12 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "deS" = (
-/obj/machinery/power/rad_collector/anchored,
 /obj/structure/window/plasma/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
 	},
+/obj/machinery/power/tesla_coil,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "deU" = (
@@ -52378,7 +52378,6 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "dfm" = (
-/obj/machinery/power/rad_collector/anchored,
 /obj/structure/window/plasma/reinforced{
 	dir = 1
 	},
@@ -52386,6 +52385,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
+/obj/machinery/power/tesla_coil,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "dfp" = (
@@ -56214,6 +56214,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"eBR" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "eBX" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -57731,6 +57741,15 @@
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
+"fHy" = (
+/obj/structure/window/plasma/reinforced,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/obj/machinery/power/tesla_coil,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "fId" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -70967,6 +70986,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"pIA" = (
+/obj/structure/window/plasma/reinforced{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/machinery/power/tesla_coil,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "pJO" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/donkpockets,
@@ -125094,7 +125122,7 @@ def
 dej
 aFC
 deC
-deC
+eBR
 dlI
 aKH
 aMk
@@ -125609,11 +125637,11 @@ del
 aFC
 djt
 aMk
-daZ
+fHy
 dbb
 aMk
 aNv
-dfk
+pIA
 dfq
 djt
 dfF


### PR DESCRIPTION
Replaces Rad collectors on meta with Tesla coils

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces 4 of the rad collectors on Meta with the Tesla coil.

## Why It's Good For The Game

I think it's fucking hilarious.
Also, Engine Variety.

## Changelog
:cl:
add: Added tesla coils to Metastation, replacing 4 of the rad collectors
add: Added CO2 can to engine instead of an N2 can
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
