### PR TITLE
The Xenoarch update we needed.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -19995,6 +19995,7 @@
 	},
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
+/obj/item/workplacecapsule/xenoarch,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bhH" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -82037,6 +82037,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/item/workplacecapsule/xenoarch,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "djZ" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -81335,6 +81335,7 @@
 "xtp" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/item/workplacecapsule/xenoarch,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "xtB" = (

--- a/_maps/map_files/PackedStation/PackedStation.dmm
+++ b/_maps/map_files/PackedStation/PackedStation.dmm
@@ -22390,6 +22390,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/relic,
+/obj/item/workplacecapsule/xenoarch,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "gCB" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -27335,14 +27335,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
-"bvZ" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/dark,
-/area/science/explab)
 "bwa" = (
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
@@ -27353,7 +27345,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bwc" = (
-/obj/machinery/chem_master,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
@@ -27884,19 +27875,15 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/chem_heater,
+/obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxK" = (
 /obj/structure/chair/stool,
-/obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxL" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
-	},
+/obj/structure/closet/xenoarch,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxM" = (
@@ -28452,31 +28439,17 @@
 	dir = 1;
 	network = list("ss13","rd")
 	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/storage/toolbox/mechanical,
+/obj/machinery/xenoarch/researcher,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bzi" = (
 /obj/structure/table,
-/obj/item/electropack,
-/obj/item/taperecorder,
-/obj/item/screwdriver,
+/obj/machinery/xenoarch/scanner,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bzj" = (
 /obj/structure/table,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
+/obj/machinery/xenoarch/digger,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bzk" = (
@@ -56946,8 +56919,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/machinery/xenoarch/recoverer,
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
 "tBb" = (
@@ -102682,7 +102654,7 @@ bqv
 bqs
 aaM
 buD
-bvZ
+bxJ
 bxJ
 tAK
 bAF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Xenoarch is no longer a prototype at all. 
There's now a capsule on every map.

## Why It's Good For The Game

Moves Xenoarch out of the prototype realm and into reality.

## Changelog
:cl:
add: Added Xenoarch capsule to every map.
tweak: Swapped out the science chem lab on pubby (NOT the Chemist lab, the science chemistry lab) with a xenoarch lab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
