### PR TITLE
[PORT] The Cycling 2.0, Airlocks can now be built in game to cycle and named

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -183,7 +183,10 @@
 /obj/machinery/door/airlock/proc/update_other_id()
 	for(var/obj/machinery/door/airlock/Airlock in GLOB.airlocks)
 		if(Airlock.closeOtherId == closeOtherId && Airlock != src)
-			close_others += Airlock
+			if(!(Airlock in close_others))
+				close_others += Airlock
+			if(!(src in Airlock.close_others))
+				Airlock.close_others += src
 
 /obj/machinery/door/airlock/proc/cyclelinkairlock()
 	if (cyclelinkedairlock)
@@ -644,6 +647,10 @@
 
 /obj/machinery/door/airlock/examine(mob/user)
 	. = ..()
+	if(closeOtherId)
+		. += "<span class='warning'>This airlock cycles on ID: [sanitize(closeOtherId)].</span>"
+	else if(!closeOtherId)
+		. += "<span class='warning'>This airlock does not cycle.</span>"
 	if(obj_flags & EMAGGED)
 		. += "<span class='warning'>Its access panel is smoking slightly.</span>"
 	if(note)

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -7,6 +7,10 @@
 	var/one_access = 0
 	/// Unrestricted sides, or sides of the airlock that will open regardless of access
 	var/unres_sides = 0
+	///what name are we passing to the finished airlock
+	var/passed_name
+	///what string are we passing to the finished airlock as the cycle ID
+	var/passed_cycle_id
 	/// A holder of the electronics, in case of them working as an integrated part
 	var/holder
 
@@ -49,6 +53,8 @@
 	data["accesses"] = accesses
 	data["oneAccess"] = one_access
 	data["unres_direction"] = unres_sides
+	data["passedName"] = passed_name
+	data["passedCycleId"] = passed_cycle_id
 	return data
 
 /obj/item/electronics/airlock/ui_act(action, params)
@@ -89,6 +95,14 @@
 			if(isnull(region))
 				return
 			accesses -= get_region_accesses(region)
+			. = TRUE
+		if("passedName")
+			var/new_name = trim("[params["passedName"]]", 30)
+			passed_name = new_name
+			. = TRUE
+		if("passedCycleId")
+			var/new_cycle_id = trim(params["passedCycleId"], 30)
+			passed_cycle_id = new_cycle_id
 			. = TRUE
 
 /obj/item/electronics/airlock/ui_host()

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -259,8 +259,13 @@
 					door.req_access = electronics.accesses
 				if(created_name)
 					door.name = created_name
+				else if(electronics.passed_name)
+					door.name = sanitize(electronics.passed_name)
 				else
 					door.name = base_name
+				if(electronics.passed_cycle_id)
+					door.closeOtherId = electronics.passed_cycle_id
+					door.update_other_id()
 				door.previous_airlock = previous_assembly
 				electronics.forceMove(door)
 				door.update_icon()

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -291,12 +291,19 @@
 				new_airlock.electronics.accesses = the_rcd.airlock_electronics.accesses.Copy()
 				new_airlock.electronics.one_access = the_rcd.airlock_electronics.one_access
 				new_airlock.electronics.unres_sides = the_rcd.airlock_electronics.unres_sides
+				new_airlock.electronics.passed_name = the_rcd.airlock_electronics.passed_name
+				new_airlock.electronics.passed_cycle_id = the_rcd.airlock_electronics.passed_cycle_id
 			if(new_airlock.electronics.one_access)
 				new_airlock.req_one_access = new_airlock.electronics.accesses
 			else
 				new_airlock.req_access = new_airlock.electronics.accesses
 			if(new_airlock.electronics.unres_sides)
 				new_airlock.unres_sides = new_airlock.electronics.unres_sides
+			if(new_airlock.electronics.passed_name)
+				new_airlock.name = sanitize(new_airlock.electronics.passed_name)
+			if(new_airlock.electronics.passed_cycle_id)
+				new_airlock.closeOtherId = new_airlock.electronics.passed_cycle_id
+				new_airlock.update_other_id()
 			new_airlock.autoclose = TRUE
 			new_airlock.update_icon()
 			return TRUE

--- a/tgui/packages/tgui/interfaces/AirlockElectronics.js
+++ b/tgui/packages/tgui/interfaces/AirlockElectronics.js
@@ -1,5 +1,5 @@
 import { useBackend } from '../backend';
-import { Button, LabeledList, Section } from '../components';
+import { Button, Input, LabeledList, Section } from '../components';
 import { Window } from '../layouts';
 import { AccessList } from './common/AccessList';
 
@@ -8,6 +8,8 @@ export const AirlockElectronics = (props, context) => {
   const {
     oneAccess,
     unres_direction,
+    passedName,
+    passedCycleId,  
   } = data;
   const regions = data.regions || [];
   const accesses = data.accesses || [];
@@ -56,7 +58,25 @@ export const AirlockElectronics = (props, context) => {
                   unres_direction: '8',
                 })} />
             </LabeledList.Item>
-          </LabeledList>
+            <LabeledList.Item
+              label="Airlock Name">
+              <Input fluid
+                maxLength={30}
+                value={passedName}
+                onChange={(e, value) => act('passedName', {
+                  passedName: value,
+                })} />
+            </LabeledList.Item>
+            <LabeledList.Item
+              label="Cycling Id">
+              <Input fluid
+                maxLength={30}
+                value={passedCycleId}
+                onChange={(e, value) => act('passedCycleId', {
+                  passedCycleId: value,
+                })} />
+            </LabeledList.Item>
+		  </LabeledList>
         </Section>
         <AccessList
           accesses={regions}

--- a/tgui/packages/tgui/interfaces/AirlockElectronics.js
+++ b/tgui/packages/tgui/interfaces/AirlockElectronics.js
@@ -9,7 +9,7 @@ export const AirlockElectronics = (props, context) => {
     oneAccess,
     unres_direction,
     passedName,
-    passedCycleId,  
+    passedCycleId, 
   } = data;
   const regions = data.regions || [];
   const accesses = data.accesses || [];
@@ -76,7 +76,7 @@ export const AirlockElectronics = (props, context) => {
                   passedCycleId: value,
                 })} />
             </LabeledList.Item>
-		  </LabeledList>
+          </LabeledList>
         </Section>
         <AccessList
           accesses={regions}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
https://github.com/tgstation/tgstation/pull/61226
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
allows for the re/building of cycling doors
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
