### PR TITLE
Security Titles

### DIFF
--- a/ModularBungalow/altjobtitles/alt_titles.dm
+++ b/ModularBungalow/altjobtitles/alt_titles.dm
@@ -92,16 +92,16 @@
 
 //Security
 /datum/job/warden
-	alt_titles = list("Brig Chief", "Sergeant")
-	senior_title = "Sergeant Major"
+	alt_titles = list("Brig Chief", "Security Sergeant")
+	senior_title = list("Master-At-Arms", "Security Major")
 
 /datum/job/detective
 	alt_titles = list("Forensics Specialist", "Private Investigator")
-	senior_title = "Staff Sergeant"
+	senior_title = list("Intelligence Officer", "Chief Investigator")
 
 /datum/job/officer
 	alt_titles = list("Security Guard", "Deputy", "Hazardous Device Technician", "NT Military Police")
-	senior_title = "Man-at-Arms"
+	senior_title = list("Man-at-Arms", "Sergeant Officer")
 
 //Supply
 /datum/job/mining
@@ -142,6 +142,6 @@
 	senior_title = "Customs Officer"
 
 /datum/job/captain
-	alt_titles = list("Commanding Officer")
+	alt_titles = list("Commanding Officer", "Commander")
 	senior_title = list("Commodore", "Marshal")
 

--- a/ModularBungalow/altjobtitles/alt_titles.dm
+++ b/ModularBungalow/altjobtitles/alt_titles.dm
@@ -142,6 +142,6 @@
 	senior_title = "Customs Officer"
 
 /datum/job/captain
-	alt_titles = list("Commanding Officer", "Commander")
+	alt_titles = list("Commanding Officer")
 	senior_title = list("Commodore", "Marshal")
 


### PR DESCRIPTION
## About The Pull Request

Adds and changes a bunch of different security titles to fit better with the lore (that I just created). (Also, hopefully the senior titles don't break. I added a list behind a few of them to get the extra names in).

## Why It's Good For The Game

Tons of variety for the different roles is always a nice thing, especially if you want to express yourself more in your role. Also, Commander (navy) is in there for lore reasons.

## Changelog
:cl:
add: "Sergeant Officer" and "Intelligence Officer" as security titles.
tweak: Replaces "Sergeant" with "Security Sergeant", "Sergeant Major" with "Man-At-Arms" - "Security Major", and "Staff Sergeant" with "Chief Investigator"
/:cl: