### PR TITLE
SMC Major Balance changes

### DIFF
--- a/_maps/map_files/AndromedaStation/Andromeda.dmm
+++ b/_maps/map_files/AndromedaStation/Andromeda.dmm
@@ -827,7 +827,6 @@
 /obj/item/clothing/suit/jacket/miljacket,
 /obj/item/ammo_box/magazine/m9mm,
 /obj/item/gun/ballistic/automatic/pistol/ppk,
-/obj/item/clothing/suit/space/hardsuit/syndi,
 /turf/open/floor/wood,
 /area/shuttle/sbc/starfury)
 "cPN" = (
@@ -1150,8 +1149,6 @@
 /obj/item/clothing/accessory/medal/conduct,
 /obj/item/ammo_box/magazine/m9mm,
 /obj/item/gun/ballistic/automatic/pistol/ppk,
-/obj/item/clothing/suit/space/hardsuit/syndi,
-/obj/item/clothing/head/flatcap,
 /turf/open/floor/wood,
 /area/shuttle/sbc/starfury)
 "dOd" = (
@@ -1362,7 +1359,6 @@
 /obj/item/clothing/accessory/medal/conduct,
 /obj/item/clothing/head/beret/so,
 /obj/item/ammo_box/magazine/m9mm,
-/obj/item/clothing/suit/space/hardsuit/syndi,
 /turf/open/floor/wood,
 /area/shuttle/sbc/starfury)
 "euK" = (
@@ -1593,10 +1589,6 @@
 	rad_insulation = 0.1
 	},
 /area/shuttle/sbc/supermatter)
-"foi" = (
-/obj/machinery/porta_turret/syndicate/andromeda,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/shuttle/sbc/crew)
 "foD" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -1701,16 +1693,12 @@
 /area/shuttle/sbc/starfury)
 "fCx" = (
 /obj/item/ammo_casing/caseless/rocket,
-/obj/item/ammo_casing/caseless/rocket,
-/obj/item/ammo_casing/caseless/rocket,
 /obj/structure/closet/secure_closet{
 	anchored = 1;
 	icon_state = "tac";
 	name = "Specialst Ammo Locker";
 	req_access_txt = "151"
 	},
-/obj/item/ammo_box/magazine/mm712x82,
-/obj/item/ammo_box/magazine/mm712x82,
 /obj/item/ammo_box/magazine/m12g,
 /obj/item/ammo_box/magazine/m12g,
 /obj/item/ammo_box/magazine/m12g,
@@ -1718,12 +1706,12 @@
 /obj/item/ammo_box/magazine/m12g/slug,
 /obj/item/ammo_box/magazine/m12g/meteor,
 /obj/item/ammo_box/magazine/m12g,
-/obj/item/ammo_box/magazine/mm712x82/ap,
+/obj/item/ammo_casing/caseless/rocket/weak,
+/obj/item/ammo_casing/caseless/rocket/weak,
 /obj/item/ammo_box/magazine/mm712x82,
-/obj/item/ammo_casing/caseless/rocket/weak,
-/obj/item/ammo_casing/caseless/rocket/weak,
-/obj/item/ammo_casing/caseless/rocket/weak,
-/obj/item/ammo_casing/caseless/rocket/weak,
+/obj/item/ammo_box/magazine/mm712x82,
+/obj/item/ammo_box/magazine/mm712x82,
+/obj/item/ammo_box/magazine/mm712x82/ap,
 /turf/open/floor/pod/light,
 /area/shuttle/sbc/armory)
 "fDh" = (
@@ -1858,7 +1846,6 @@
 	icon_state = "pipe11-2"
 	},
 /obj/structure/rack,
-/obj/item/clothing/suit/space/hardsuit/cybersun,
 /obj/item/gun/ballistic/shotgun/bulldog/unrestricted,
 /turf/open/floor/pod/dark,
 /area/shuttle/sbc/armory)
@@ -2146,7 +2133,6 @@
 /obj/item/clothing/accessory/medal/conduct,
 /obj/item/clothing/head/beret/so,
 /obj/item/ammo_box/magazine/m9mm,
-/obj/item/clothing/suit/space/hardsuit/syndi,
 /turf/open/floor/wood,
 /area/shuttle/sbc/starfury)
 "hri" = (
@@ -2190,7 +2176,6 @@
 /area/shuttle/sbc/starfury)
 "hFf" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/space/hardsuit/cybersun,
 /obj/item/minigunpack,
 /turf/open/floor/pod/light,
 /area/shuttle/sbc/armory)
@@ -2239,10 +2224,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark/side,
 /area/shuttle/sbc/med)
-"hRz" = (
-/obj/machinery/porta_turret/syndicate/andromeda,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/shuttle/sbc/armory)
 "hSe" = (
 /obj/structure/sign/directions/security{
 	pixel_x = 32;
@@ -2565,7 +2546,6 @@
 /area/shuttle/sbc/engi)
 "jbR" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/space/hardsuit/cybersun,
 /obj/item/storage/belt/nano_blade,
 /turf/open/floor/pod/light,
 /area/shuttle/sbc/armory)
@@ -3824,7 +3804,6 @@
 	dir = 8;
 	icon_state = "pipe11-2"
 	},
-/obj/item/clothing/suit/space/hardsuit/cybersun,
 /obj/item/gun/ballistic/rocketlauncher/unrestricted{
 	name = "\improper SADAR"
 	},
@@ -5019,7 +4998,19 @@
 	icon_state = "pipe11-2"
 	},
 /obj/structure/rack,
-/obj/item/clothing/suit/space/hardsuit/cybersun,
+/obj/item/grenade/frag,
+/obj/item/grenade/frag,
+/obj/item/grenade/frag,
+/obj/item/grenade/frag,
+/obj/item/grenade/frag,
+/obj/item/grenade/frag,
+/obj/item/grenade/frag,
+/obj/item/grenade/frag,
+/obj/item/grenade/frag,
+/obj/item/grenade/frag,
+/obj/item/grenade/frag,
+/obj/item/grenade/frag,
+/obj/item/storage/belt/grenade,
 /obj/item/gun/grenadelauncher,
 /turf/open/floor/pod/dark,
 /area/shuttle/sbc/armory)
@@ -5441,18 +5432,10 @@
 /area/shuttle/sbc/supermatter)
 "tsA" = (
 /obj/structure/rack,
-/obj/item/clothing/head/helmet/space/eva/syndie,
-/obj/item/clothing/head/helmet/space/eva/syndie,
-/obj/item/clothing/head/helmet/space/eva/syndie,
-/obj/item/clothing/head/helmet/space/eva/syndie,
-/obj/item/clothing/head/helmet/space/eva/syndie,
+/obj/item/clothing/suit/space/eva,
 /obj/item/clothing/head/helmet/space/eva/syndie,
 /obj/item/clothing/suit/space/eva,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/helmet/space/eva/syndie,
 /turf/open/floor/pod/light,
 /area/shuttle/sbc/armory)
 "ttK" = (
@@ -5467,10 +5450,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/sbc/bay)
-"tvB" = (
-/obj/machinery/porta_turret/syndicate/andromeda,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/shuttle/sbc/starfury)
 "txK" = (
 /obj/structure/closet/crate,
 /obj/item/ammo_box/magazine/m556,
@@ -5680,7 +5659,6 @@
 	dir = 8;
 	icon_state = "pipe11-2"
 	},
-/obj/item/clothing/suit/space/hardsuit/cybersun,
 /obj/item/gun/ballistic/automatic/l6_saw/unrestricted,
 /turf/open/floor/pod/light,
 /area/shuttle/sbc/armory)
@@ -5729,7 +5707,7 @@
 /obj/item/ammo_box/magazine/glock,
 /obj/item/ammo_box/magazine/glock,
 /obj/item/ammo_box/magazine/glock,
-/obj/item/clothing/suit/space/hardsuit/syndi/elite,
+/obj/item/clothing/suit/space/hardsuit/cybersun,
 /turf/open/floor/carpet,
 /area/shuttle/sbc/crew)
 "uqc" = (
@@ -5762,10 +5740,6 @@
 	icon_state = "whitehall"
 	},
 /area/shuttle/sbc/med)
-"urf" = (
-/obj/machinery/porta_turret/syndicate/andromeda,
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/sbc/engi)
 "utF" = (
 /obj/structure/chair/comfy{
 	dir = 4
@@ -35812,7 +35786,7 @@ dOd
 dOd
 dOd
 dOd
-tvB
+dOd
 cve
 cve
 cve
@@ -36103,7 +36077,7 @@ jtB
 djf
 djf
 djf
-foi
+djf
 cve
 cve
 cve
@@ -36350,7 +36324,7 @@ cve
 cve
 cve
 cve
-foi
+djf
 djf
 djf
 djf
@@ -36633,7 +36607,7 @@ dDa
 dDa
 dDa
 mln
-urf
+gyu
 cve
 cve
 cve
@@ -39463,7 +39437,7 @@ ogZ
 mln
 mln
 mln
-urf
+gyu
 cve
 cve
 cve
@@ -41519,7 +41493,7 @@ ogZ
 mln
 mln
 mln
-urf
+gyu
 cve
 cve
 cve
@@ -44343,7 +44317,7 @@ dDa
 dDa
 dDa
 mln
-urf
+gyu
 cve
 cve
 cve
@@ -44574,7 +44548,7 @@ cve
 cve
 cve
 cve
-hRz
+nBJ
 nBJ
 nBJ
 nBJ
@@ -44841,7 +44815,7 @@ vNs
 nBJ
 nBJ
 nBJ
-hRz
+nBJ
 cve
 cve
 cve
@@ -45064,7 +45038,7 @@ pxV
 dOd
 dOd
 dOd
-tvB
+dOd
 cve
 cve
 cve


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes to the amount of hardsuit numbers on Syndicate Marine Corps.

All Bloodred Hardsuits have been removed.
Staff Officers, Pilot Officers and the Req Chief no longer get their special hardsuits.
The amount of Syndicate EVA hardsuits in the armory has been reduced to two.
All Cybersun hardsuits from the Armory have been removed.
The First Officer now gets a Cybersun Hardsuit

## Why It's Good For The Game

The Marines got a LOT of hardsuits, I tossed the balance in the total opposite way when I made this PR after marines won a grand total of 0 rounds.
Now Xenos can't last 10 minutes.

Of Course, this means that stealing the command hardsuits is now something that MPs can arrest for, alongside protecting the officers groundside.

## Changelog
:cl:
balance: changed the amount of hardsuits marines get from 24 total to 7
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
