### PR TITLE
Plasmamen can wear hats

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -55,6 +55,7 @@
 #define ANTI_TINFOIL_MANEUVER   (1<<12) //Hats with negative effects when worn (i.e the tinfoil hat).
 #define DANGEROUS_OBJECT    (1<<13)     //Clothes that cause a larger notification when placed on a person.
 #define LARGE_WORN_ICON    (1<<14)     //Clothes that use large icons, for applying the proper overlays like blood
+#define PLASMAMAN_HELMET_EXEMPT (1<<15) //To prevent placing said objects on plasmaman helmets
 
 /// Flags for the organ_flags var on /obj/item/organ
 

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -6,7 +6,7 @@
 	armor = list(MELEE = 15, BULLET = 5, LASER = 20, ENERGY = 10, BOMB = 20, BIO = 10, RAD = 20, FIRE = 100, ACID = 50, WOUND = 10) // surprisingly robust against head trauma
 	flags_inv = 0
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-	clothing_flags = SNUG_FIT
+	clothing_flags = SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
 	resistance_flags = FIRE_PROOF
 	dynamic_hair_suffix = "+generic"
 	light_system = MOVABLE_LIGHT_DIRECTIONAL
@@ -57,7 +57,7 @@
 	hat_type = "red"
 	dog_fashion = null
 	name = "firefighter helmet"
-	clothing_flags = STOPSPRESSUREDAMAGE
+	clothing_flags = STOPSPRESSUREDAMAGE | PLASMAMAN_HELMET_EXEMPT
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_HELM_MAX_TEMP_PROTECT
 	cold_protection = HEAD
@@ -77,7 +77,7 @@
 	icon_state = "hardhat0_white"
 	inhand_icon_state = "hardhat0_white"
 	hat_type = "white"
-	clothing_flags = STOPSPRESSUREDAMAGE
+	clothing_flags = STOPSPRESSUREDAMAGE | PLASMAMAN_HELMET_EXEMPT
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_HELM_MAX_TEMP_PROTECT
 	cold_protection = HEAD
@@ -97,7 +97,7 @@
 	dog_fashion = null
 	name = "atmospheric technician's firefighting helmet"
 	desc = "A firefighter's helmet, able to keep the user cool in any situation."
-	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | BLOCK_GAS_SMOKE_EFFECT
+	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | BLOCK_GAS_SMOKE_EFFECT | PLASMAMAN_HELMET_EXEMPT
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
@@ -158,7 +158,7 @@
 	inhand_icon_state = "hardhat0_white"
 	light_range = 4 //Boss always takes the best stuff
 	hat_type = "white"
-	clothing_flags = STOPSPRESSUREDAMAGE
+	clothing_flags = STOPSPRESSUREDAMAGE | PLASMAMAN_HELMET_EXEMPT
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_HELM_MAX_TEMP_PROTECT
 	cold_protection = HEAD

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -6,7 +6,7 @@
 	armor = list(MELEE = 15, BULLET = 5, LASER = 20, ENERGY = 10, BOMB = 20, BIO = 10, RAD = 20, FIRE = 100, ACID = 50, WOUND = 10) // surprisingly robust against head trauma
 	flags_inv = 0
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
-	clothing_flags = SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
+	clothing_flags = SNUG_FIT
 	resistance_flags = FIRE_PROOF
 	dynamic_hair_suffix = "+generic"
 	light_system = MOVABLE_LIGHT_DIRECTIONAL
@@ -57,7 +57,7 @@
 	hat_type = "red"
 	dog_fashion = null
 	name = "firefighter helmet"
-	clothing_flags = STOPSPRESSUREDAMAGE | PLASMAMAN_HELMET_EXEMPT
+	clothing_flags = STOPSPRESSUREDAMAGE
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_HELM_MAX_TEMP_PROTECT
 	cold_protection = HEAD
@@ -77,7 +77,7 @@
 	icon_state = "hardhat0_white"
 	inhand_icon_state = "hardhat0_white"
 	hat_type = "white"
-	clothing_flags = STOPSPRESSUREDAMAGE | PLASMAMAN_HELMET_EXEMPT
+	clothing_flags = STOPSPRESSUREDAMAGE
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_HELM_MAX_TEMP_PROTECT
 	cold_protection = HEAD
@@ -158,7 +158,7 @@
 	inhand_icon_state = "hardhat0_white"
 	light_range = 4 //Boss always takes the best stuff
 	hat_type = "white"
-	clothing_flags = STOPSPRESSUREDAMAGE | PLASMAMAN_HELMET_EXEMPT
+	clothing_flags = STOPSPRESSUREDAMAGE
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_HELM_MAX_TEMP_PROTECT
 	cold_protection = HEAD

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -9,7 +9,7 @@
 	heat_protection = HEAD
 	max_heat_protection_temperature = HELMET_MAX_TEMP_PROTECT
 	strip_delay = 60
-	clothing_flags = SNUG_FIT
+	clothing_flags = SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEHAIR
 
@@ -188,7 +188,7 @@
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
-	clothing_flags = STOPSPRESSUREDAMAGE
+	clothing_flags = STOPSPRESSUREDAMAGE | PLASMAMAN_HELMET_EXEMPT
 	strip_delay = 80
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	dog_fashion = null

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -71,7 +71,7 @@
 	icon_state = "syndicate-helm-black-red"
 	inhand_icon_state = "syndicate-helm-black-red"
 	desc = "A plastic replica of a Syndicate agent's space helmet. You'll look just like a real murderous Syndicate agent in this! This is a toy, it is not made for use in space!"
-	clothing_flags = SNUG_FIT
+	clothing_flags = SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 
 /obj/item/clothing/head/cueball
@@ -88,7 +88,7 @@
 	desc = "A ball of white styrofoam. So festive."
 	icon_state = "snowman_h"
 	inhand_icon_state = "snowman_h"
-	clothing_flags = SNUG_FIT
+	clothing_flags = SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 
@@ -183,7 +183,7 @@
 	desc = "Bkaw!"
 	icon_state = "chickenhead"
 	inhand_icon_state = "chickensuit"
-	clothing_flags = SNUG_FIT
+	clothing_flags = SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 
 /obj/item/clothing/head/griffin
@@ -191,7 +191,7 @@
 	desc = "Why not 'eagle head'? Who knows."
 	icon_state = "griffinhat"
 	inhand_icon_state = "griffinhat"
-	clothing_flags = SNUG_FIT
+	clothing_flags = SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 
 /obj/item/clothing/head/bearpelt
@@ -205,7 +205,7 @@
 	icon_state = "xenos"
 	inhand_icon_state = "xenos_helm"
 	desc = "A helmet made out of chitinous alien hide."
-	clothing_flags = SNUG_FIT
+	clothing_flags = SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -28,7 +28,7 @@
 	visor_flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDESNOUT
 	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	resistance_flags = FIRE_PROOF
-	clothing_flags = SNUG_FIT
+	clothing_flags = SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
 
 /obj/item/clothing/head/welding/attack_self(mob/user)
 	weldingvisortoggle(user)
@@ -147,7 +147,7 @@
 	icon_state = "hardhat0_pumpkin"
 	inhand_icon_state = "hardhat0_pumpkin"
 	hat_type = "pumpkin"
-	clothing_flags = SNUG_FIT
+	clothing_flags = SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0)
 	light_range = 2 //luminosity when on
@@ -298,7 +298,7 @@
 	desc = "A crude helmet made out of bronze plates. It offers very little in the way of protection."
 	icon = 'icons/obj/clothing/clockwork_garb.dmi'
 	icon_state = "clockwork_helmet_old"
-	clothing_flags = SNUG_FIT
+	clothing_flags = SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
 	flags_inv = HIDEEARS|HIDEHAIR
 	armor = list(MELEE = 5, BULLET = 0, LASER = -5, ENERGY = -15, BOMB = 10, BIO = 0, RAD = 0, FIRE = 20, ACID = 20)
 

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -6,7 +6,7 @@
 	name = "space helmet"
 	icon_state = "spaceold"
 	desc = "A special helmet with solar UV shielding to protect your eyes from harmful rays."
-	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | SNUG_FIT
+	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
 	inhand_icon_state = "spaceold"
 	permeability_coefficient = 0.01
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 100, RAD = 50, FIRE = 80, ACID = 70)

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -166,7 +166,7 @@
 		attached_hat = null
 		update_icon()
 	else
-		to_chat(user, "<span class='notice'>You can't remove [attached_hat.name] from the helmet, because your hands are full!</span>")
+		to_chat(user, "<span class='notice'>You can't remove [attached_hat.name] from the helmet because your hands are full!</span>")
 
 /obj/item/clothing/head/helmet/space/plasmaman/security
 	name = "security plasma envirosuit helmet"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -157,10 +157,16 @@
 	. = COMSIG_CLICK_ALT
 	if(!attached_hat)
 		return
-	user.put_in_active_hand(attached_hat)
-	to_chat(user, "<span class='notice'>You removed [attached_hat.name] from helmet!</span>")
-	attached_hat = null
-	update_icon()
+	if(user.put_in_active_hand(attached_hat))
+		to_chat(user, "<span class='notice'>You removed [attached_hat.name] from helmet!</span>")
+		attached_hat = null
+		update_icon()
+	else if(user.put_in_inactive_hand(attached_hat))
+		to_chat(user, "<span class='notice'>You removed [attached_hat.name] from helmet!</span>")
+		attached_hat = null
+		update_icon()
+	else
+		to_chat(user, "<span class='notice'>You can't remove [attached_hat.name] because your hands are full!</span>")
 
 /obj/item/clothing/head/helmet/space/plasmaman/security
 	name = "security plasma envirosuit helmet"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -104,7 +104,7 @@
 	if(istype(hitting_item, /obj/item/clothing/head))
 		var/obj/item/clothing/hitting_clothing = hitting_item
 		if(hitting_clothing.clothing_flags & PLASMAMAN_HELMET_EXEMPT)
-			to_chat(user, "<span class='notice'>You cannot place [hitting_clothing.name] on the helmet!</span>")
+			to_chat(user, "<span class='notice'>You cannot place the [hitting_clothing.name] on the helmet!</span>")
 			return
 		if(attached_hat)
 			to_chat(user, "<span class='notice'>There's already something placed on the helmet!</span>")

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -104,13 +104,13 @@
 	if(istype(hitting_item, /obj/item/clothing/head))
 		var/obj/item/clothing/hitting_clothing = hitting_item
 		if(hitting_clothing.clothing_flags & PLASMAMAN_HELMET_EXEMPT)
-			to_chat(user, "<span class='notice'>You cannot place [hitting_clothing.name] on helmet!</span>")
+			to_chat(user, "<span class='notice'>You cannot place [hitting_clothing.name] on the helmet!</span>")
 			return
 		if(attached_hat)
-			to_chat(user, "<span class='notice'>There's already something placed on helmet!</span>")
+			to_chat(user, "<span class='notice'>There's already something placed on the helmet!</span>")
 			return
 		attached_hat = hitting_clothing
-		to_chat(user, "<span class='notice'>You placed [hitting_clothing.name] on helmet!</span>")
+		to_chat(user, "<span class='notice'>You placed [hitting_clothing.name] on the helmet! Keep in mind this is merely cosmetic: hat lights, stats or anything else won't work!</span>")
 		hitting_clothing.forceMove(src)
 		update_icon()
 /obj/item/clothing/head/helmet/space/plasmaman/worn_overlays(isinhands)
@@ -158,15 +158,15 @@
 	if(!attached_hat)
 		return
 	if(user.put_in_active_hand(attached_hat))
-		to_chat(user, "<span class='notice'>You removed [attached_hat.name] from helmet!</span>")
+		to_chat(user, "<span class='notice'>You removed [attached_hat.name] from the helmet!</span>")
 		attached_hat = null
 		update_icon()
 	else if(user.put_in_inactive_hand(attached_hat))
-		to_chat(user, "<span class='notice'>You removed [attached_hat.name] from helmet!</span>")
+		to_chat(user, "<span class='notice'>You removed [attached_hat.name] from the helmet!</span>")
 		attached_hat = null
 		update_icon()
 	else
-		to_chat(user, "<span class='notice'>You can't remove [attached_hat.name] because your hands are full!</span>")
+		to_chat(user, "<span class='notice'>You can't remove [attached_hat.name] from the helmet, because your hands are full!</span>")
 
 /obj/item/clothing/head/helmet/space/plasmaman/security
 	name = "security plasma envirosuit helmet"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -167,7 +167,7 @@
 		attached_hat = null
 		update_icon()
 	else
-		to_chat(user, "<span class='notice'>You can't remove the [attached_hat.name] from the helmet because your hands are full!</span>")
+		to_chat(user, "<span class='notice'>You can't remove the [attached_hat.name] from the helmet because you don't have available hands!</span>")
 
 /obj/item/clothing/head/helmet/space/plasmaman/security
 	name = "security plasma envirosuit helmet"

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -4,7 +4,7 @@
 	icon_state = "bio"
 	desc = "A hood that protects the head and face from biological contaminants."
 	permeability_coefficient = 0.01
-	clothing_flags = THICKMATERIAL | BLOCK_GAS_SMOKE_EFFECT | SNUG_FIT
+	clothing_flags = THICKMATERIAL | BLOCK_GAS_SMOKE_EFFECT | SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
 	armor = list(MELEE = 0, BULLET = 0, LASER = 20,ENERGY = 0, BOMB = 0, BIO = 100, RAD = 80, FIRE = 30, ACID = 100)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDEFACE|HIDESNOUT
 	resistance_flags = ACID_PROOF | FIRE_PROOF

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -56,7 +56,7 @@
 	name = "bomb hood"
 	desc = "Use in case of bomb."
 	icon_state = "bombsuit"
-	clothing_flags = THICKMATERIAL | SNUG_FIT
+	clothing_flags = THICKMATERIAL | SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
 	armor = list(MELEE = 20, BULLET = 0, LASER = 20,ENERGY = 30, BOMB = 100, BIO = 0, RAD = 0, FIRE = 80, ACID = 50)
 	flags_inv = HIDEFACE|HIDEMASK|HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	dynamic_hair_suffix = ""
@@ -119,7 +119,7 @@
 	name = "radiation hood"
 	icon_state = RAD
 	desc = "A hood with radiation protective properties. The label reads, 'Made with lead. Please do not consume insulation.'"
-	clothing_flags = THICKMATERIAL | SNUG_FIT
+	clothing_flags = THICKMATERIAL | SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
 	flags_inv = HIDEMASK|HIDEEARS|HIDEFACE|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 60, RAD = 100, FIRE = 30, ACID = 30)
 	strip_delay = 60

--- a/code/modules/hydroponics/beekeeping/beekeeper_suit.dm
+++ b/code/modules/hydroponics/beekeeping/beekeeper_suit.dm
@@ -4,7 +4,7 @@
 	desc = "Keeps the lil buzzing buggers out of your eyes."
 	icon_state = "beekeeper"
 	inhand_icon_state = "beekeeper"
-	clothing_flags = THICKMATERIAL | SNUG_FIT
+	clothing_flags = THICKMATERIAL | SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
 
 
 /obj/item/clothing/suit/beekeeper_suit


### PR DESCRIPTION
## About The Pull Request

Allows plasmamen to wear hats on top of their helmets. They are purely cosmetic, so, if they have any kind of protection, it won't be used.
I made a define to make some exceptions, so plasmamen can't wear some things such as space suit helmets, the atmospherics firefighting helmet and security helmets, because they are limited and they shouldn't be used for cosmetic purposes.

It's mechanic is simple: you can wear any kind of headwear by having it in hand and clicking on your envirohelm, and remove it by alt+leftclicking it.

Here's a video showing the whole thing:

https://youtu.be/wuII64lIn0E

## Why It's Good For The Game

More cosmetic possibilities for plasmamen!

## Changelog
:cl:
add: a define to make headwear exceptions
add: allow plasmamen to wear things on their helmets
add: alt+click to take off the hat on the helmet
del: alt+click for helmet visor
/:cl: