### PR TITLE
[NEEDS TM]Revolution Overhaul Part 1

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -743,6 +743,17 @@ SUBSYSTEM_DEF(job)
 		if(player.mind && (player.mind.assigned_role in GLOB.command_positions))
 			. |= player.mind
 
+//////////////////////////////////
+//Keeps track of all rev targets//
+//////////////////////////////////
+/datum/controller/subsystem/job/proc/get_all_targets()
+	. = list()
+	for(var/i in GLOB.mob_list)
+		var/mob/player = i
+		var/list/targets = list("Captain", "Head of Security", "Head of Personnel", "Warden", "Detective")
+		if(player.mind && (player.mind.assigned_role in targets))
+			. |= player.mind
+
 //////////////////////////////////////////////
 //Keeps track of all living security members//
 //////////////////////////////////////////////

--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -94,3 +94,12 @@
 	mission = "Create entertainment for the crew."
 	polldesc = "a Code Rainbow Nanotrasen Emergency Response Party"
 	code = "Rainbow"
+
+/datum/ert/marine
+	roles = list(/datum/antagonist/ert/marine)
+	leader_role = /datum/antagonist/ert/marine/leader
+	rename_team = "Marine Squad"
+	code = "Red"
+	mission = "Save the innocent, punish the guilty."
+	polldesc = "a Nanotrasen military squad"
+

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -13,7 +13,7 @@
 	report_type = "revolution"
 	antag_flag = ROLE_REV
 	false_report_weight = 10
-	restricted_jobs = list("Prisoner","Security Officer", "Warden", "Detective", "AI", "Cyborg","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Quartermaster", "Research Director", "Chief Medical Officer")
+	restricted_jobs = list("Prisoner","Security Officer", "Warden", "Detective", "AI", "Cyborg","Captain", "Secretary", "Head of Personnel", "Head of Security", "Chief Engineer", "Quartermaster", "Research Director", "Chief Medical Officer")
 	required_jobs = list(list("Captain"=1),list("Head of Personnel"=1),list("Head of Security"=1),list("Warden"=1),list("Detective"=1)) //One Target present
 	required_players = 15
 	required_enemies = 2

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -224,9 +224,9 @@
 		if (world.time > endtime && !fuckingdone)
 			fuckingdone = TRUE
 			priority_announce("This is Admiral Jill Ness, I have received information of revolutionaires on [station_name()]. I have dispatched a marine strike team to your station. We expect you all to behave.", 'sound/voice/beepsky/radio.ogg')
-			addtimer(CALLBACK(src, .proc/send_in_the_fuzz), 5 MINUTES)
+			addtimer(CALLBACK(src, .proc/send_in_the_marines), 5 MINUTES)
 
-/datum/game_mode/revolution/marines/proc/send_in_the_fuzz()
+/datum/game_mode/revolution/marines/proc/send_in_the_marines()
 	var/cops_to_send = /datum/antagonist/ert/marine
 	var/announcement_message = "The Marines are on their way."
 	var/announcer = "NT Marine Division"

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -14,15 +14,15 @@
 	antag_flag = ROLE_REV
 	false_report_weight = 10
 	restricted_jobs = list("Prisoner","Security Officer", "Warden", "Detective", "AI", "Cyborg","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Quartermaster", "Research Director", "Chief Medical Officer")
-	required_jobs = list(list("Captain"=1),list("Head of Personnel"=1),list("Head of Security"=1),list("Chief Engineer"=1),list("Research Director"=1),list("Chief Medical Officer"=1)) //Any head present
-	required_players = 30
+	required_jobs = list(list("Captain"=1),list("Head of Personnel"=1),list("Head of Security"=1),list("Warden"=1),list("Detective"=1)) //One Target present
+	required_players = 15
 	required_enemies = 2
 	recommended_enemies = 3
 	enemy_minimum_age = 14
 
 	announce_span = "Revolution"
 	announce_text = "Some crewmembers are attempting a coup!\n\
-	<span class='danger'>Revolutionaries</span>: Expand your cause and overthrow the heads of staff by execution or otherwise.\n\
+	<span class='danger'>Revolutionaries</span>: Expand your cause and overthrow the Captain, HOS, HOP, Warden and Detective by execution or otherwise.\n\
 	<span class='notice'>Crew</span>: Prevent the revolutionaries from taking over the station."
 
 	var/finished = 0
@@ -59,7 +59,7 @@
 	return TRUE
 
 /datum/game_mode/revolution/post_setup()
-	var/list/heads = SSjob.get_living_heads()
+	var/list/heads = list("Captain", "Head of Security", "Head of Personnel", "Warden", "Detective")
 	var/list/sec = SSjob.get_living_sec()
 	var/weighted_score = min(max(round(heads.len - ((8 - sec.len) / 3)),1),max_headrevs)
 
@@ -157,7 +157,7 @@
 /datum/game_mode/revolution/set_round_result()
 	..()
 	if(finished == 1)
-		SSticker.mode_result = "win - heads killed"
+		SSticker.mode_result = "win - targets killed"
 		SSticker.news_report = REVS_WIN
 	else if(finished == 2)
 		SSticker.mode_result = "loss - rev heads killed"
@@ -166,12 +166,12 @@
 //TODO What should be displayed for revs in non-rev rounds
 /datum/game_mode/revolution/special_report()
 	if(finished == 1)
-		return "<div class='panel redborder'><span class='redtext big'>The heads of staff were killed or exiled! The revolutionaries win!</span></div>"
+		return "<div class='panel redborder'><span class='redtext big'>The targets were killed or exiled! The revolutionaries win!</span></div>"
 	else if(finished == 2)
-		return "<div class='panel redborder'><span class='redtext big'>The heads of staff managed to stop the revolution!</span></div>"
+		return "<div class='panel redborder'><span class='redtext big'>The targets managed to stop the revolution!</span></div>"
 
 /datum/game_mode/revolution/generate_report()
-	return "Employee unrest has spiked in recent weeks, with several attempted mutinies on heads of staff. Some crew have been observed using flashbulb devices to blind their colleagues, \
+	return "Employee unrest has spiked in recent weeks, with several attempted mutinies on certain targets. Some crew have been observed using flashbulb devices to blind their colleagues, \
 		who then follow their orders without question and work towards dethroning departmental leaders. Watch for behavior such as this with caution. If the crew attempts a mutiny, you and \
 		your heads of staff are fully authorized to execute them using lethal weaponry - they will be later cloned and interrogated at Central Command."
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -15,7 +15,7 @@
 	false_report_weight = 10
 	restricted_jobs = list("Prisoner","Security Officer", "Warden", "Detective", "AI", "Cyborg","Captain", "Secretary", "Head of Personnel", "Head of Security", "Chief Engineer", "Quartermaster", "Research Director", "Chief Medical Officer")
 	required_jobs = list(list("Captain"=1),list("Head of Personnel"=1),list("Head of Security"=1),list("Warden"=1),list("Detective"=1)) //One Target present
-	required_players = 15
+	required_players = 8
 	required_enemies = 2
 	recommended_enemies = 3
 	enemy_minimum_age = 14
@@ -59,7 +59,7 @@
 	return TRUE
 
 /datum/game_mode/revolution/post_setup()
-	var/list/heads = list("Captain", "Head of Security", "Head of Personnel", "Warden", "Detective")
+	var/list/heads = SSjob.get_all_targets()
 	var/list/sec = SSjob.get_living_sec()
 	var/weighted_score = min(max(round(heads.len - ((8 - sec.len) / 3)),1),max_headrevs)
 

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -207,6 +207,13 @@
 	H.equipOutfit(outfit)
 
 
+/datum/antagonist/ert/marine
+	outfit = /datum/outfit/job/ntmarine
+
+/datum/antagonist/ert/marine/leader
+	outfit = /datum/outfit/job/ntsquadleader
+
+
 /datum/antagonist/ert/greet()
 	if(!ert_team)
 		return

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -302,7 +302,7 @@
 	var/list/ex_revs = list()
 
 /datum/team/revolution/proc/update_objectives(initial = FALSE)
-	var/untracked_heads = list("Captain", "Head of Security", "Head of Personnel", "Warden", "Detective")
+	var/untracked_heads = SSjob.get_all_targets()
 	for(var/datum/objective/mutiny/O in objectives)
 		untracked_heads -= O.target
 	for(var/datum/mind/M in untracked_heads)
@@ -326,7 +326,7 @@
 /datum/team/revolution/proc/update_heads()
 	if(SSticker.HasRoundStarted())
 		var/list/datum/mind/head_revolutionaries = head_revolutionaries()
-		var/list/datum/mind/heads = list("Captain", "Head of Security", "Head of Personnel", "Warden", "Detective")
+		var/list/datum/mind/heads = SSjob.get_all_targets()
 		var/list/sec = SSjob.get_all_sec()
 
 		if(head_revolutionaries.len < max_headrevs && head_revolutionaries.len < round(heads.len - ((8 - sec.len) / 3)))
@@ -491,7 +491,7 @@
 		rev_part += printplayerlist(revs, !check_rev_victory())
 		result += rev_part.Join("<br>")
 
-	var/list/heads = list("Captain", "Head of Security", "Head of Personnel", "Warden", "Detective")
+	var/list/heads = SSjob.get_all_targets()
 	if(heads.len)
 		var/head_text = "<span class='header'>The targets were:</span>"
 		head_text += "<ul class='playerlist'>"

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -18,8 +18,10 @@
 
 /datum/antagonist/rev/can_be_owned(datum/mind/new_owner)
 	. = ..()
+	var/list/targets = list("Captain","Head of Personnel","Head of Security","Warden","Detective", "NT Squad Leader", "NT Captain") //cannot be revved
+
 	if(.)
-		if(new_owner.assigned_role in GLOB.command_positions)
+		if(new_owner.assigned_role in targets)
 			return FALSE
 		if(new_owner.unconvertable)
 			return FALSE
@@ -50,7 +52,7 @@
 	. = ..()
 
 /datum/antagonist/rev/greet()
-	to_chat(owner, "<span class='userdanger'>You are now a revolutionary! Help your cause. Do not harm your fellow freedom fighters. You can identify your comrades by the red \"R\" icons, and your leaders by the blue \"R\" icons. Help them kill the heads to win the revolution!</span>")
+	to_chat(owner, "<span class='userdanger'>You are now a revolutionary! Do not needlessly slaughter, there will be consequences. Help your cause. Do not harm your fellow freedom fighters. You can identify your comrades by the red \"R\" icons, and your leaders by the blue \"R\" icons. Join together and kill the HOS, HOP, Captain, Detective and Warden!!</span>")
 	owner.announce_objectives()
 
 /datum/antagonist/rev/create_team(datum/team/revolution/new_team)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -14,7 +14,7 @@
 	var/datum/team/revolution/rev_team
 
 	/// What message should the player receive when they are being demoted, and the revolution has won?
-	var/victory_message = "The revolution has overpowered the command staff! Viva la revolution! Execute any head of staff and security should you find them alive."
+	var/victory_message = "The revolution has  slaughtered the targets! Viva la revolution! Execute any security should you find them alive."
 
 /datum/antagonist/rev/can_be_owned(datum/mind/new_owner)
 	. = ..()
@@ -302,7 +302,7 @@
 	var/list/ex_revs = list()
 
 /datum/team/revolution/proc/update_objectives(initial = FALSE)
-	var/untracked_heads = SSjob.get_all_heads()
+	var/untracked_heads = list("Captain", "Head of Security", "Head of Personnel", "Warden", "Detective")
 	for(var/datum/objective/mutiny/O in objectives)
 		untracked_heads -= O.target
 	for(var/datum/mind/M in untracked_heads)
@@ -326,7 +326,7 @@
 /datum/team/revolution/proc/update_heads()
 	if(SSticker.HasRoundStarted())
 		var/list/datum/mind/head_revolutionaries = head_revolutionaries()
-		var/list/datum/mind/heads = SSjob.get_all_heads()
+		var/list/datum/mind/heads = list("Captain", "Head of Security", "Head of Personnel", "Warden", "Detective")
 		var/list/sec = SSjob.get_all_sec()
 
 		if(head_revolutionaries.len < max_headrevs && head_revolutionaries.len < round(heads.len - ((8 - sec.len) / 3)))
@@ -491,9 +491,9 @@
 		rev_part += printplayerlist(revs, !check_rev_victory())
 		result += rev_part.Join("<br>")
 
-	var/list/heads = SSjob.get_all_heads()
+	var/list/heads = list("Captain", "Head of Security", "Head of Personnel", "Warden", "Detective")
 	if(heads.len)
-		var/head_text = "<span class='header'>The heads of staff were:</span>"
+		var/head_text = "<span class='header'>The targets were:</span>"
 		head_text += "<ul class='playerlist'>"
 		for(var/datum/mind/head in heads)
 			var/target = (head in targets)
@@ -525,7 +525,7 @@
 
 	var/heads_report = "<b>Heads of Staff</b><br>"
 	heads_report += "<table cellspacing=5>"
-	for(var/datum/mind/N in SSjob.get_living_heads())
+	for(var/datum/mind/N in list("Captain", "Head of Security", "Head of Personnel", "Warden", "Detective"))
 		var/mob/M = N.current
 		if(M)
 			heads_report += "<tr><td><a href='?_src_=holder;[HrefToken()];adminplayeropts=[REF(M)]'>[M.real_name]</a>[M.client ? "" : " <i>(No Client)</i>"][M.stat == DEAD ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -835,7 +835,6 @@
 #include "code\game\gamemodes\meteor\meteors.dm"
 #include "code\game\gamemodes\monkey\monkey.dm"
 #include "code\game\gamemodes\nuclear\nuclear.dm"
-#include "code\game\gamemodes\revolution\marines.dm"
 #include "code\game\gamemodes\revolution\revolution.dm"
 #include "code\game\gamemodes\sandbox\airlock_maker.dm"
 #include "code\game\gamemodes\sandbox\h_sandbox.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -835,6 +835,7 @@
 #include "code\game\gamemodes\meteor\meteors.dm"
 #include "code\game\gamemodes\monkey\monkey.dm"
 #include "code\game\gamemodes\nuclear\nuclear.dm"
+#include "code\game\gamemodes\revolution\marines.dm"
 #include "code\game\gamemodes\revolution\revolution.dm"
 #include "code\game\gamemodes\sandbox\airlock_maker.dm"
 #include "code\game\gamemodes\sandbox\h_sandbox.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Starts to overhaul the Revolution game mode.
THIS NEEDS TO BE TMED
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I see rev problems boils down to one issue:
People just indiscriminately kill. There is no reprecussions for killing an innocent.

I will solve this by doing two things:
Part 1: Changing targets from All heads to Captain, HOS, HOP, Detective and Warden.
 All heads already get sunglasses, and should get the strategic option of flashing for a stronger ally earlier on. They will likely get mindshielded fast. Capture them fast or you lose this oppurtunity.
RD, CE, QM and CMO should NOT be killed just for having bad luck. They don't even start mindshielded, nor are they "High Ranking". They are the 4th-7th in line for command and not security members

Part 2: Giving the dead a choice to respawn later in the round.
Revs tend to snowball fast, and as a fuck you for murderboning I'm automatically spawning dead people as some sort of riot police 40 minutes into the round, and every 10 after that.

I want to add revs back into rotation and I've laid out the issues I have
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked the revolution targets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
