### PR TITLE
Nerfs Chestbursting and AI Xenos

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -117,7 +117,9 @@
 
 	if(gib_on_success)
 		new_xeno.visible_message("<span class='danger'>[new_xeno] bursts out of [owner] in a shower of gore!</span>", "<span class='userdanger'>You exit [owner], your previous host.</span>", "<span class='hear'>You hear organic matter ripping and tearing!</span>")
-		owner.gib()
+		owner.spill_organs()
+		owner.adjustBruteLoss(250)
+		new /obj/effect/gibspawner/generic(get_turf(H))
 	else
 		new_xeno.visible_message("<span class='danger'>[new_xeno] wriggles out of [owner]!</span>", "<span class='userdanger'>You exit [owner], your previous host.</span>")
 		owner.adjustBruteLoss(40)

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -119,7 +119,7 @@
 		new_xeno.visible_message("<span class='danger'>[new_xeno] bursts out of [owner] in a shower of gore!</span>", "<span class='userdanger'>You exit [owner], your previous host.</span>", "<span class='hear'>You hear organic matter ripping and tearing!</span>")
 		owner.spill_organs()
 		owner.adjustBruteLoss(250)
-		new /obj/effect/gibspawner/generic(get_turf(H))
+		new /obj/effect/gibspawner/generic(get_turf(owner))
 	else
 		new_xeno.visible_message("<span class='danger'>[new_xeno] wriggles out of [owner]!</span>", "<span class='userdanger'>You exit [owner], your previous host.</span>")
 		owner.adjustBruteLoss(40)

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -10,8 +10,8 @@
 	speed = -3
 	butcher_results = list(/obj/item/food/meat/slab/xeno = 4,
 							/obj/item/stack/sheet/animalhide/xeno = 1)
-	maxHealth = 250
-	health = 250
+	maxHealth = 120
+	health = 120
 	harm_intent_damage = 5
 	obj_damage = 60
 	melee_damage_lower = 35
@@ -62,8 +62,8 @@
 	icon_state = "aliens"
 	icon_living = "aliens"
 	icon_dead = "aliens_dead"
-	health = 300
-	maxHealth = 300
+	health = 160
+	maxHealth = 160
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	ranged = 1
@@ -78,8 +78,8 @@
 	icon_state = "alienq"
 	icon_living = "alienq"
 	icon_dead = "alienq_dead"
-	health = 600
-	maxHealth = 600
+	health = 300
+	maxHealth = 300
 	melee_damage_lower = 55
 	melee_damage_upper = 72
 	ranged = 1
@@ -135,8 +135,8 @@
 	health_doll_icon = "alienq"
 	bubble_icon = "alienroyal"
 	move_to_delay = 4
-	maxHealth = 700
-	health = 700
+	maxHealth = 400
+	health = 400
 	butcher_results = list(/obj/item/food/meat/slab/xeno = 10,
 							/obj/item/stack/sheet/animalhide/xeno = 2)
 	mob_size = MOB_SIZE_LARGE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Now chestbursting no longer gibs! (fucking FINALLY)

All the AI Xenos that got their health doubled in a patch have their health reduced
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This was back when we used mixed PVE+PVP Syndiecorps.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: chestbursting now CHESTBURSTS and doesn't gib
balance: ai xenos used on rock and charlie station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
