### PR TITLE
Adds flaps to Remora cargo conveyors.

### DIFF
--- a/_maps/map_files/RemoraStation/RemoraStation.dmm
+++ b/_maps/map_files/RemoraStation/RemoraStation.dmm
@@ -18362,6 +18362,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
+"oiO" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "cargoload"
+	},
+/obj/structure/plasticflaps,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "ojh" = (
 /obj/machinery/suit_storage_unit/engine,
 /obj/machinery/status_display/evac{
@@ -21989,6 +22001,18 @@
 /obj/structure/closet/wardrobe/orange,
 /turf/open/floor/plasteel/dark/side,
 /area/crew_quarters/fitness/locker_room)
+"rpR" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "cargounload"
+	},
+/obj/structure/plasticflaps,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "rqv" = (
 /obj/structure/table/reinforced,
 /obj/item/stamp/denied{
@@ -72485,11 +72509,11 @@ aaa
 aaa
 aaa
 bWV
-uKo
+rpR
 pcN
 diU
 pcN
-fdI
+oiO
 bWV
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request

Adds airtight flaps to the conveyor belts that go onto and off of the cargo bay shuttle.

## Why It's Good For The Game

So it dosent depressurized when left open, every other station has it why not this one?

## Changelog
:cl:
add: Adds airtight flaps to cargo conveyor belts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
